### PR TITLE
[FIX] Enforce tlsVerifyCert and harden error handling

### DIFF
--- a/Sources/KurrentDB/Core/Additions/EventStore_Client_StreamIdentifier+Additions.swift
+++ b/Sources/KurrentDB/Core/Additions/EventStore_Client_StreamIdentifier+Additions.swift
@@ -9,8 +9,10 @@ import Foundation
 import GRPCEncapsulates
 
 extension EventStore_Client_StreamIdentifier {
-    func toIdentifier() -> StreamIdentifier {
-        let name = String(data: streamName, encoding: .utf8)
-        return .init(name: name!)
+    func toIdentifier() throws(KurrentError) -> StreamIdentifier {
+        guard let name = String(data: streamName, encoding: .utf8) else {
+            throw .internalParsingError(reason: "Stream name contains invalid UTF-8 data.")
+        }
+        return .init(name: name)
     }
 }

--- a/Sources/KurrentDB/Core/ClientSettings/ClientSettings.swift
+++ b/Sources/KurrentDB/Core/ClientSettings/ClientSettings.swift
@@ -170,7 +170,6 @@ extension ClientSettings {
         }
     }
 
-
     public func httpUri(endpoint: Endpoint) -> URL? {
         var components = URLComponents()
         components.scheme = secure ? "https" : "http"

--- a/Sources/KurrentDB/Core/ClientSettings/ClientSettings.swift
+++ b/Sources/KurrentDB/Core/ClientSettings/ClientSettings.swift
@@ -170,6 +170,7 @@ extension ClientSettings {
         }
     }
 
+
     public func httpUri(endpoint: Endpoint) -> URL? {
         var components = URLComponents()
         components.scheme = secure ? "https" : "http"
@@ -455,6 +456,7 @@ extension ClientSettings {
                 if let trustRoots {
                     config.trustRoots = trustRoots
                 }
+                config.serverCertificateVerification = tlsVerifyCert ? .fullVerification : .noVerification
             }
         } else {
             .plaintext

--- a/Sources/KurrentDB/Core/ClientSettings/Endpoint.swift
+++ b/Sources/KurrentDB/Core/ClientSettings/Endpoint.swift
@@ -46,7 +46,10 @@ extension Endpoint {
 
 extension Endpoint: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
-        self = Endpoint(string: value)!
+        guard let endpoint = Endpoint(string: value) else {
+            preconditionFailure("Invalid endpoint string literal: \"\(value)\". Expected format: \"host\" or \"host:port\".")
+        }
+        self = endpoint
     }
 }
 

--- a/Sources/KurrentDB/Core/Error/KurrentError.swift
+++ b/Sources/KurrentDB/Core/Error/KurrentError.swift
@@ -172,7 +172,8 @@ func withRethrowingError<T>(usage: String, action: @Sendable () async throws -> 
     } catch let error as RPCError {
         try error.rethrow(usage: usage)
     } catch {
-        throw .internalClientError(reason: "`\(usage)` failed. full error: \(error)")
+        logger.debug("'\(usage)' failed with unexpected error: \(error)")
+        throw .internalClientError(reason: "`\(usage)` failed.")
     }
     throw .internalClientError(reason: "`\(usage)` failed.")
 }
@@ -185,7 +186,8 @@ func withRethrowingError<T>(usage: String, action: @Sendable () throws -> T) thr
     } catch let error as RPCError {
         try error.rethrow(usage: usage)
     } catch {
-        throw .internalClientError(reason: "`\(usage)` failed. full error: \(error).")
+        logger.debug("'\(usage)' failed with unexpected error: \(error)")
+        throw .internalClientError(reason: "`\(usage)` failed.")
     }
     throw .internalClientError(reason: "`\(usage)` failed.")
 }
@@ -254,7 +256,8 @@ extension IOError {
              111:  // Linux: ECONNREFUSED
             throw .grpcConnectionError(cause: origin)
         default:
-            throw .internalClientError(reason: "`\(usage)` failed, full error: \(origin).")
+            logger.debug("'\(usage)' failed with IO error (errno: \(errnoCode)): \(origin)")
+            throw .internalClientError(reason: "`\(usage)` failed.")
         }
     }
 }

--- a/Sources/KurrentDB/Core/Event/RecordedEvent.swift
+++ b/Sources/KurrentDB/Core/Event/RecordedEvent.swift
@@ -57,7 +57,7 @@ public struct RecordedEvent: EventStoreEvent, Sendable {
         }
 
         let contentType = ContentType(rawValue: message.metadata["content-type"] ?? ContentType.binary.rawValue) ?? .unknown
-        let streamIdentifier = message.streamIdentifier.toIdentifier()
+        let streamIdentifier = try message.streamIdentifier.toIdentifier()
         let revision = message.streamRevision
         let position: StreamPosition = .at(commitPosition: message.commitPosition, preparePosition: message.preparePosition)
 
@@ -74,7 +74,7 @@ public struct RecordedEvent: EventStoreEvent, Sendable {
         }
 
         let contentType = ContentType(rawValue: message.metadata["content-type"] ?? ContentType.binary.rawValue) ?? .unknown
-        let streamIdentifier = message.streamIdentifier.toIdentifier()
+        let streamIdentifier = try message.streamIdentifier.toIdentifier()
         let revision = message.streamRevision
         let position: StreamPosition = .at(commitPosition: message.commitPosition, preparePosition: message.preparePosition)
 


### PR DESCRIPTION
## Summary
- **Enforce `tlsVerifyCert`**: Apply `serverCertificateVerification` in `transportSecurity` so the `tlsVerifyCert` setting actually controls certificate verification behavior
- **Eliminate force unwraps**: Replace force unwrap in `StreamIdentifier` UTF-8 decoding with typed throw, and in `Endpoint` string literal with `preconditionFailure` with clear message
- **Prevent error info leakage**: Move full error details from user-facing `KurrentError` messages to `logger.debug`, keeping external messages concise

## Test plan
- [ ] `swift build` passes
- [ ] `swift build --build-tests` passes
- [ ] Verify TLS connection with `tlsVerifyCert=false` now skips certificate verification
- [ ] Verify TLS connection with `tlsVerifyCert=true` (default) still performs full verification
- [ ] Verify invalid UTF-8 stream names throw `internalParsingError` instead of crashing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid stream identifiers with descriptive failures
  * TLS certificate verification now explicitly respects verification settings for stronger security
  * Stricter validation of endpoint literals to fail fast on invalid values
  * Better propagation and logging of unexpected errors during event processing and client operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->