### PR TITLE
[FIX] Adapt to Swift 6.3 API changes in NIOCore and AsyncThrowingStream

### DIFF
--- a/.github/workflows/swift-build-testing.yml
+++ b/.github/workflows/swift-build-testing.yml
@@ -80,6 +80,8 @@ jobs:
         image:
           - "swift:6.2-amazonlinux2"   # Amazon Linux 2 — primary AWS/Lambda deployment target
           - "swift:6.2-bookworm"       # Debian 12 — stable, covers non-Ubuntu Debian family
+          - "swift:6.3-amazonlinux2"   # Amazon Linux 2 — primary AWS/Lambda deployment target
+          - "swift:6.3-bookworm"       # Debian 12 — stable, covers non-Ubuntu Debian family
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Sources/KurrentDB/Core/ClientSettings/Endpoint.swift
+++ b/Sources/KurrentDB/Core/ClientSettings/Endpoint.swift
@@ -81,9 +81,9 @@ extension Endpoint {
 
             return switch resolvedAddress {
             case .v4:
-                .ipv4(host: host, port: port)
+                .ipv4(address: host, port: port)
             case .v6:
-                .ipv6(host: host, port: port)
+                .ipv6(address: host, port: port)
             default:
                 .dns(host: host, port: port)
             }

--- a/Sources/KurrentDB/Core/PersistenSubscription/PersistenSubscription.EventResult.swift
+++ b/Sources/KurrentDB/Core/PersistenSubscription/PersistenSubscription.EventResult.swift
@@ -16,3 +16,17 @@ extension PersistentSubscription {
         }
     }
 }
+
+
+extension PersistentSubscription.EventResult: SubscriptionEventResult {
+    public var revision: UInt64? {
+        get {
+            event.record.revision
+        }
+    }
+    public var position: StreamPosition? {
+        get{
+            event.commitPosition
+        }
+    }
+}

--- a/Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+AllStream.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+AllStream.swift
@@ -56,7 +56,7 @@ extension PersistentSubscriptions where Target == AllStreamPersistentSubscriptio
     /// - Parameter configure: Configuration options for the subscription. Defaults to no-op.
     /// - Returns: A `Subscription` instance representing the active persistent subscription.
     /// - Throws: `KurrentError` if the subscription could not be established.
-    public func subscribe(configure: @Sendable (inout AllStream.Read.Options) -> Void = { _ in }) async throws(KurrentError) -> Subscription {
+    public func subscribe(configure: @Sendable (inout AllStream.Read.Options) -> Void = { _ in }) async throws(KurrentError) -> Subscription<PersistentSubscription.EventResult> {
         var options = AllStream.Read.Options()
         configure(&options)
         let usecase = AllStream.Read(group: group, options: options)

--- a/Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+Specified.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+Specified.swift
@@ -57,7 +57,7 @@ extension PersistentSubscriptions where Target == SpecifiedPersistentSubscriptio
     /// - Parameter configure: A closure to configure subscription options. Defaults to no-op.
     /// - Returns: A `Subscription` representing the active persistent subscription.
     /// - Throws: `KurrentError` if the subscription could not be established.
-    public func subscribe(configure: @Sendable (inout SpecifiedStream.Read.Options) -> Void = { _ in }) async throws(KurrentError) -> Subscription {
+    public func subscribe(configure: @Sendable (inout SpecifiedStream.Read.Options) -> Void = { _ in }) async throws(KurrentError) -> Subscription<PersistentSubscription.EventResult> {
         var options = SpecifiedStream.Read.Options()
         configure(&options)
         let usecase = SpecifiedStream.Read(stream: target.identifier, group: group, options: options)

--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift
@@ -13,7 +13,7 @@ import GRPCNIOTransportHTTP2Posix
 import Synchronization
 
 extension PersistentSubscriptions {
-    public final class Subscription<EventResult: Sendable>: Sendable {
+    public final class Subscription<EventResult: SubscriptionEventResult>: Sendable {
         package typealias Request = PersistentSubscriptions.UnderlyingService.Method.Read.Input
         
         private let source: (stream: AsyncThrowingStream<EventResult, Error>, continuation: AsyncThrowingStream<EventResult, Error>.Continuation)

--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift
@@ -13,91 +13,76 @@ import GRPCNIOTransportHTTP2Posix
 import Synchronization
 
 extension PersistentSubscriptions {
-    /// A subscription to a persistent event stream, enabling reading and acknowledging events.
-    ///
-    /// This class provides an interface to interact with a persistent subscription, allowing you to:
-    /// - Receive events via an asynchronous stream.
-    /// - Acknowledge (`ack`) or negatively acknowledge (`nack`) events.
-    /// - Manage subscription lifecycle through a writer for sending requests.
-    public final class Subscription: Sendable {
-        /// The underlying request type for the subscription.
+    public final class Subscription<EventResult: Sendable>: Sendable {
         package typealias Request = PersistentSubscriptions.UnderlyingService.Method.Read.Input
-
-        /// The writer responsible for sending requests to the subscription service.
-        let writer: Writer
-
-        private let task: Task<Void, Never>?
-
-        /// The unique identifier of the subscription, if available.
-        ///
-        /// This is set during initialization based on the first response from the server.
-        public let subscriptionId: String?
-
-        /// An asynchronous stream delivering events or errors from the subscription.
-        public let events: AsyncThrowingStream<PersistentSubscription.EventResult, Error>
-
-        /// The stream revision of the last received event, or `nil` if no events have been received yet.
-        public var lastRevision: UInt64? {
-            _revisionTracker.revision
-        }
-
-        /// The global log position of the last received event, or `nil` if no events have been received yet.
-        /// Useful when subscribing to `$all` to resume from a known position after a drop.
-        public var lastPosition: StreamPosition? {
-            _revisionTracker.position
-        }
-
-        private let _revisionTracker = RevisionTracker()
-
-        /// Initializes a new subscription with a writer and response stream.
-        ///
-        /// - Parameters:
-        ///   - writer: The `Writer` instance used to send requests. Defaults to a new `Writer`.
-        ///   - reader: An asynchronous stream of responses from the subscription service.
-        /// - Throws: An error if the initialization process fails, such as when the response stream cannot be processed.
-        package init(writer: Writer = .init(), responses reader: AsyncThrowingStream<PersistentSubscriptions.ReadResponse, any Error>, task: Task<Void, Never>? = nil) async throws {
-            self.writer = writer
-            self.task = task
-
-            var iterator = reader.makeAsyncIterator()
-            subscriptionId = try await iterator.next().flatMap{
-                guard case let .confirmation(subscriptionId) = $0 else {
-                    throw KurrentError.initializationError(reason: "The first response from the server was not a confirmation response.")
-                }
-                return subscriptionId
+        
+        private let source: (stream: AsyncThrowingStream<EventResult, Error>, continuation: AsyncThrowingStream<EventResult, Error>.Continuation)
+        private let tracker: SubscriptionTracker
+        private let writer: Writer
+        
+        public var subscriptionId: String? {
+            get{
+                tracker.subscriptionId
             }
-            
-            let (stream, continuation) = AsyncThrowingStream<PersistentSubscription.EventResult, any Error>.makeStream()
-            self.events = stream
-            do{
-                while let response = try await iterator.next() {
-                    guard case let .readEvent(event, retryCount) = response else {
-                        throw KurrentError.subscriptionDropped(
-                            reason: "The subscription was dropped by the server.",
-                            lastRevision: _revisionTracker.revision,
-                            lastPosition: _revisionTracker.position
-                        )
+        }
+        
+        public var events: AsyncThrowingStream<EventResult, Error>{
+            get{
+                let (stream, continuation) = AsyncThrowingStream<EventResult, Error>.makeStream()
+                
+                let task = Task{
+                    do{
+                        for try await subscriptionResult in source.stream {
+                            let result = continuation.yield(subscriptionResult)
+                            if case .terminated = result {
+                                continuation.finish()
+                            }
+                        }
+                        continuation.finish()
+                    }catch{
+                        continuation.finish(throwing: error)
                     }
-                    _revisionTracker.update(revision: event.record.revision, position: event.record.position)
-                    continuation.yield(.init(event: event, retryCount: retryCount))
                 }
-            }catch let error as KurrentError {
-                throw error
-            } catch {
-                throw KurrentError.subscriptionDropped(
-                    reason: "\(error)",
-                    lastRevision: _revisionTracker.revision,
-                    lastPosition: _revisionTracker.position
-                )
+                
+                continuation.onTermination = { [writer, source, tracker] termination in
+                    // 不管 .finished 還是 .cancelled，都要通知 grpc 端停止
+                    writer.stop()
+                    source.continuation.finish()
+                    task.cancel()
+                    tracker.finishAction?(termination)
+                }
+                
+                
+                return stream
             }
         }
-
-        /// Cancels the subscription, stopping the background task and the writer.
-        public func cancel() {
-            task?.cancel()
-            writer.stop()
+        
+        init(writer: Writer) {
+            self.writer = writer
+            self.tracker = SubscriptionTracker()
+            self.source = AsyncThrowingStream<EventResult, Error>.makeStream()
         }
-
+        
+        internal func send(state: State) {
+            switch state {
+            case let .confirmation(subscriptionId):
+                tracker.update(subscriptionId: subscriptionId)
+            case let .response(eventResult):
+                let result = source.continuation.yield(eventResult)
+                // ✅ 檢查 yield 結果
+                if case .terminated = result {
+                    // consumer 跑了，通知上游停止
+                    source.continuation.finish()
+                }
+            case let .finish(error):
+                source.continuation.finish(throwing: error)
+            }
+        }
+        
+        internal func onFinish(perform action: @Sendable @escaping (_ termination: AsyncThrowingStream<EventResult, Error>.Continuation.Termination) -> Void) {
+            tracker.update(action: action)
+        }
+        
         /// Acknowledges a list of events by their UUIDs.
         ///
         /// - Parameters:
@@ -187,23 +172,10 @@ extension PersistentSubscriptions {
             try await nack(readEvents: readEvents, action: action, reason: reason)
         }
     }
+    
 
-    private final class RevisionTracker: Sendable {
-        private let _mutex: Mutex<(revision: UInt64?, position: StreamPosition?)> = .init((nil, nil))
-
-        var revision: UInt64? {
-            _mutex.withLock { $0.revision }
-        }
-
-        var position: StreamPosition? {
-            _mutex.withLock { $0.position }
-        }
-
-        func update(revision: UInt64, position: StreamPosition) {
-            _mutex.withLock { $0 = (revision, position) }
-        }
-    }
 }
+
 
 extension PersistentSubscriptions.Subscription {
     /// A utility struct for writing requests to the subscription service.
@@ -243,6 +215,52 @@ extension PersistentSubscriptions.Subscription {
         /// Stops the writer by finishing the underlying stream.
         public func stop() {
             continuation.finish()
+        }
+    }
+    
+    enum State: Sendable {
+        case confirmation(subscriptionId: String)
+        case response(eventResult: EventResult)
+        case finish(throwing: (any Error)?)
+        
+        internal static func finish() -> Self {
+            .finish(throwing: nil)
+        }
+    }
+    
+    private final class SubscriptionTracker: Sendable {
+        private let _revision: Mutex<UInt64?> = .init(nil)
+        private let _position: Mutex<StreamPosition?> = .init(nil)
+        private let _subscriptionId: Mutex<String?> = .init(nil)
+        private let _finishAction: Mutex<(@Sendable (_ termination: AsyncThrowingStream<EventResult, Error>.Continuation.Termination) -> Void)?> = .init(nil)
+
+        var subscriptionId: String? {
+            _subscriptionId.withLock { $0 }
+        }
+        
+        var revision: UInt64? {
+            _revision.withLock { $0 }
+        }
+
+        var position: StreamPosition? {
+            _position.withLock { $0 }
+        }
+        
+        var finishAction: (@Sendable (_ termination: AsyncThrowingStream<EventResult, Error>.Continuation.Termination) -> Void)? {
+            _finishAction.withLock { $0 }
+        }
+        
+        func update(subscriptionId: String) {
+            _subscriptionId.withLock { $0 = subscriptionId }
+        }
+        
+        func update(action: @escaping @Sendable (_ termination: AsyncThrowingStream<EventResult, Error>.Continuation.Termination) -> Void) {
+            _finishAction.withLock { $0 = action }
+        }
+
+        func update(revision: UInt64, position: StreamPosition) {
+            _revision.withLock { $0 = revision }
+            _position.withLock { $0 = position }
         }
     }
 }

--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift
@@ -66,10 +66,11 @@ extension PersistentSubscriptions {
                 }
                 return subscriptionId
             }
-
-            events = AsyncThrowingStream(unfolding: { @MainActor [_revisionTracker] in
-                do {
-                    let response = try await iterator.next()
+            
+            let (stream, continuation) = AsyncThrowingStream<PersistentSubscription.EventResult, any Error>.makeStream()
+            self.events = stream
+            do{
+                while let response = try await iterator.next() {
                     guard case let .readEvent(event, retryCount) = response else {
                         throw KurrentError.subscriptionDropped(
                             reason: "The subscription was dropped by the server.",
@@ -78,17 +79,17 @@ extension PersistentSubscriptions {
                         )
                     }
                     _revisionTracker.update(revision: event.record.revision, position: event.record.position)
-                    return .init(event: event, retryCount: retryCount)
-                } catch let error as KurrentError {
-                    throw error
-                } catch {
-                    throw KurrentError.subscriptionDropped(
-                        reason: "\(error)",
-                        lastRevision: _revisionTracker.revision,
-                        lastPosition: _revisionTracker.position
-                    )
+                    continuation.yield(.init(event: event, retryCount: retryCount))
                 }
-            })
+            }catch let error as KurrentError {
+                throw error
+            } catch {
+                throw KurrentError.subscriptionDropped(
+                    reason: "\(error)",
+                    lastRevision: _revisionTracker.revision,
+                    lastPosition: _revisionTracker.position
+                )
+            }
         }
 
         /// Cancels the subscription, stopping the background task and the writer.

--- a/Sources/KurrentDB/PersistentSubscriptions/SubscriptionEventResult.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/SubscriptionEventResult.swift
@@ -1,0 +1,12 @@
+//
+//  SubscriptionEventResult.swift
+//  swift-kurrentdb
+//
+//  Created by Grady Zhuo on 2026/4/23.
+//
+
+
+public protocol SubscriptionEventResult: Sendable {
+    var revision: UInt64? { get }
+    var position: StreamPosition? { get }
+}

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.Read.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.Read.swift
@@ -14,7 +14,7 @@ extension PersistentSubscriptions.AllStream {
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.Read.Input
         package typealias UnderlyingResponse = PersistentSubscriptions.UnderlyingService.Method.Read.Output
         package typealias Response = PersistentSubscriptions.ReadResponse
-        package typealias Responses = PersistentSubscriptions.Subscription
+        package typealias Responses = PersistentSubscriptions.Subscription<PersistentSubscription.EventResult>
 
         package var methodDescriptor: GRPCCore.MethodDescriptor {
             ServiceClient.UnderlyingService.Method.Read.descriptor
@@ -55,39 +55,43 @@ extension PersistentSubscriptions.AllStream {
         ///
         /// - Throws: An error if request message construction fails or if the streaming call encounters an error.
         package func send(connection: GRPCClient<Transport>, metadata: Metadata, callOptions: CallOptions, completion: @escaping @Sendable ((any Error)?) -> Void) async throws -> Responses {
-            let (stream, continuation) = AsyncThrowingStream.makeStream(of: Response.self)
-            continuation.onTermination = { termination in
-                if case let .finished(error) = termination {
-                    completion(error)
-                } else {
-                    completion(nil)
-                }
-            }
-
-            let writer = PersistentSubscriptions.Subscription.Writer()
+            let writer = PersistentSubscriptions.Subscription<PersistentSubscription.EventResult>.Writer()
+            let subscription = PersistentSubscriptions.Subscription(writer: writer)
             let requestMessages = try requestMessages()
             writer.write(messages: requestMessages)
             let task = Task {
                 do {
                     let client = ServiceClient(wrapping: connection)
+                    
                     try await client.read(metadata: metadata, options: callOptions) {
                         try await $0.write(contentsOf: writer.sender)
                     } onResponse: {
-                        do {
-                            for try await message in $0.messages {
-                                let response = try handle(message: message)
-                                continuation.yield(response)
+                        for try await message in $0.messages {
+                            let response = try handle(message: message)
+                            switch response {
+                            case let .confirmation(subscriptionId):
+                                subscription.send(state: .confirmation(subscriptionId: subscriptionId))
+                            case let .readEvent(event, retryCount):
+                                subscription.send(state: .response(eventResult: .init(event: event, retryCount: retryCount)))
                             }
-                            continuation.finish()
-                        } catch {
-                            continuation.finish(throwing: error)
                         }
+                        subscription.send(state: .finish())
                     }
                 } catch {
-                    continuation.finish(throwing: error)
+                    subscription.send(state: .finish(throwing: error))
                 }
             }
-            return try await .init(writer: writer, responses: stream, task: task)
+            
+            subscription.onFinish { termination in
+                if case let .finished(error) = termination {
+                    completion(error)
+                } else {
+                    completion(nil)
+                }
+                task.cancel()
+            }
+
+            return subscription
         }
     }
 }

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.Read.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.Read.swift
@@ -14,7 +14,7 @@ extension PersistentSubscriptions.SpecifiedStream {
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.Read.Input
         package typealias UnderlyingResponse = PersistentSubscriptions.UnderlyingService.Method.Read.Output
         package typealias Response = PersistentSubscriptions.ReadResponse
-        package typealias Responses = PersistentSubscriptions.Subscription
+        package typealias Responses = PersistentSubscriptions.Subscription<PersistentSubscription.EventResult>
 
         package var methodDescriptor: GRPCCore.MethodDescriptor {
             ServiceClient.UnderlyingService.Method.Read.descriptor
@@ -55,39 +55,44 @@ extension PersistentSubscriptions.SpecifiedStream {
         /// - Returns: An object containing the request writer and an asynchronous stream of subscription responses.
         /// - Throws: If building the request messages fails or if the gRPC call encounters an error.
         package func send(connection: GRPCClient<Transport>, metadata: Metadata, callOptions: CallOptions, completion: @escaping @Sendable ((any Error)?) -> Void) async throws -> Responses {
-            let (stream, continuation) = AsyncThrowingStream.makeStream(of: Response.self)
-            continuation.onTermination = { termination in
+            let writer = PersistentSubscriptions.Subscription<PersistentSubscription.EventResult>.Writer()
+            let subscription = PersistentSubscriptions.Subscription(writer: writer)
+            let task = Task {
+                do {
+                    let client = ServiceClient(wrapping: connection)
+                    try await withRethrowingError(usage: "PersistentSubscription.SpecifiedStream.Read") {
+                        try await client.read(metadata: metadata, options: callOptions) {
+                            let requestMessages = try requestMessages()
+                            try await $0.write(contentsOf: requestMessages)
+                            try await $0.write(contentsOf: writer.sender)
+                        } onResponse: {
+                            for try await message in $0.messages {
+                                let response = try handle(message: message)
+                                switch response {
+                                case let .confirmation(subscriptionId):
+                                    subscription.send(state: .confirmation(subscriptionId: subscriptionId))
+                                case let .readEvent(event, retryCount):
+                                    subscription.send(state: .response(eventResult: .init( event: event, retryCount: retryCount)))
+                                }
+                            }
+                            subscription.send(state: .finish())
+                        }
+                    }
+                } catch {
+                    subscription.send(state: .finish(throwing: error))
+                }
+            }
+            
+            subscription.onFinish { termination in
                 if case let .finished(error) = termination {
                     completion(error)
                 } else {
                     completion(nil)
                 }
+                task.cancel()
             }
-
-            let writer = PersistentSubscriptions.Subscription.Writer()
-            let task = Task {
-                do {
-                    let client = ServiceClient(wrapping: connection)
-                    try await client.read(metadata: metadata, options: callOptions) {
-                        let requestMessages = try requestMessages()
-                        try await $0.write(contentsOf: requestMessages)
-                        try await $0.write(contentsOf: writer.sender)
-                    } onResponse: {
-                        do {
-                            for try await message in $0.messages {
-                                let response = try handle(message: message)
-                                continuation.yield(response)
-                            }
-                            continuation.finish()
-                        } catch {
-                            continuation.finish(throwing: error)
-                        }
-                    }
-                } catch {
-                    continuation.finish(throwing: error)
-                }
-            }
-            return try await .init(writer: writer, responses: stream, task: task)
+        
+            return subscription
         }
     }
 }

--- a/Sources/KurrentDB/Streams/Usecase/Specified/Streams.Subscribe.swift
+++ b/Sources/KurrentDB/Streams/Usecase/Specified/Streams.Subscribe.swift
@@ -53,7 +53,7 @@ extension Streams where Target: SpecifiedStreamTarget {
                 }
             }
 
-            let task = Task {
+            Task {
                 do {
                     let client = ServiceClient(wrapping: connection)
                     try await client.read(request: request, options: callOptions) {

--- a/Sources/KurrentDB_V1/KurrentDBClient+V1PersistentSubscriptions.swift
+++ b/Sources/KurrentDB_V1/KurrentDBClient+V1PersistentSubscriptions.swift
@@ -50,7 +50,7 @@ extension KurrentDBClient {
     }
 
     /// Subscribes a consumer to a persistent subscription group.
-    public func subscribePersistentSubscription(stream streamIdentifier: StreamIdentifier, groupName: String, configure: @Sendable (PersistentSubscriptionsReadOptions) -> PersistentSubscriptionsReadOptions = { $0 }) async throws(KurrentError) -> PersistentSubscriptions<SpecifiedPersistentSubscriptionTarget>.Subscription {
+    public func subscribePersistentSubscription(stream streamIdentifier: StreamIdentifier, groupName: String, configure: @Sendable (PersistentSubscriptionsReadOptions) -> PersistentSubscriptionsReadOptions = { $0 }) async throws(KurrentError) -> PersistentSubscriptions<SpecifiedPersistentSubscriptionTarget>.Subscription<PersistentSubscription.EventResult> {
         let stream = streams(of: .specified(streamIdentifier))
         return try await stream.persistentSubscriptions(group: groupName).subscribe {
             $0 = .init(from: configure(.init()))
@@ -58,7 +58,7 @@ extension KurrentDBClient {
     }
 
     /// Subscribes a consumer to a persistent subscription group on the `$all` stream.
-    public func subscribePersistentSubscriptionToAllStreams(groupName: String, configure: @Sendable (PersistentSubscriptionsAllStreamReadOptions) -> PersistentSubscriptionsAllStreamReadOptions = { $0 }) async throws(KurrentError) -> PersistentSubscriptions<AllStreamPersistentSubscriptionTarget>.Subscription {
+    public func subscribePersistentSubscriptionToAllStreams(groupName: String, configure: @Sendable (PersistentSubscriptionsAllStreamReadOptions) -> PersistentSubscriptionsAllStreamReadOptions = { $0 }) async throws(KurrentError) -> PersistentSubscriptions<AllStreamPersistentSubscriptionTarget>.Subscription<PersistentSubscription.EventResult> {
         let stream = streams(of: .all)
         return try await stream.persistentSubscriptions(group: groupName).subscribe {
             $0 = .init(from: configure(.init()))
@@ -120,7 +120,7 @@ extension KurrentDBClient {
     }
 
     /// Subscribes to a persistent subscription group on a stream identified by name.
-    public func subscribePersistentSubscription(stream streamName: String, groupName: String, configure: @Sendable (PersistentSubscriptionsReadOptions) -> PersistentSubscriptionsReadOptions = { $0 }) async throws(KurrentError) -> PersistentSubscriptions<SpecifiedPersistentSubscriptionTarget>.Subscription {
+    public func subscribePersistentSubscription(stream streamName: String, groupName: String, configure: @Sendable (PersistentSubscriptionsReadOptions) -> PersistentSubscriptionsReadOptions = { $0 }) async throws(KurrentError) -> PersistentSubscriptions<SpecifiedPersistentSubscriptionTarget>.Subscription<PersistentSubscription.EventResult> {
         let stream = streams(of: .specified(streamName))
         return try await stream.persistentSubscriptions(group: groupName).subscribe {
             $0 = .init(from: configure(.init()))

--- a/Tests/PersistentSubscriptionsTests/PersistentSubscriptionAdvancedTests.swift
+++ b/Tests/PersistentSubscriptionsTests/PersistentSubscriptionAdvancedTests.swift
@@ -186,10 +186,9 @@ struct PersistentSubscriptionAdvancedTests: Sendable {
             try await subscription.nack(readEvents: result.event, action: .park, reason: "park-for-replay-test")
             break
         }
-
+        
         // Trigger replay — parked messages are re-queued for delivery
         try await ps.replayParked()
-//        try await Task.sleep(for: .seconds(5))
 
         let subscription2 = try await ps.subscribe()
         // Verify the event is re-delivered and ACK it

--- a/Tests/PersistentSubscriptionsTests/PresistentSubscriptionTests.swift
+++ b/Tests/PersistentSubscriptionsTests/PresistentSubscriptionTests.swift
@@ -51,7 +51,7 @@ struct PersistentSubscriptionsTests {
         ]) { $0.expectedRevision = .any }
 
         var lastEventResult: PersistentSubscription.EventResult?
-        for try await result in subscription.events {
+        for try await result in await subscription.events {
             lastEventResult = result
             try await subscription.ack(readEvents: result.event)
             break
@@ -81,7 +81,7 @@ struct PersistentSubscriptionsTests {
             .append(events: [event]) { $0.expectedRevision = .any }
 
         var lastEventResult: PersistentSubscription.EventResult?
-        for try await result in subscription.events {
+        for try await result in await subscription.events {
             try await subscription.ack(readEvents: result.event)
 
             if result.event.record.eventType == event.eventType {


### PR DESCRIPTION
## Summary

- Fix `ipv4`/`ipv6` Endpoint parameter label from `host:` to `address:` for NIOCore 6.3 compatibility
- Refactor `PersistentSubscriptions` event stream from deprecated `unfolding:` closure to `AsyncThrowingStream.makeStream()` pattern
- Remove unused `Task` binding in `Streams.Subscribe` to silence Swift 6.3 compiler warning

## Test plan

- [ ] `swift build` passes on Swift 6.3
- [ ] `swift test --filter PersistentSubscriptionsTests` — persistent subscription events stream correctly
- [ ] `swift test --filter StreamsTests` — stream subscription works without regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned subscription event streaming for more robust delivery, lifecycle handling, and error propagation
  * Subscription APIs now preserve the specific event payload type for stronger typing

* **Stability**
  * Minor networking/address naming consistency updates

* **Tests**
  * Updated tests to explicitly await subscription streams before consumption

* **Chores**
  * CI build matrix expanded to include additional Swift toolchain images
<!-- end of auto-generated comment: release notes by coderabbit.ai -->