### PR TITLE
[REFACTOR] Cache bridge stream in Subscription.events and fix finishAction/lastRevision

### DIFF
--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift
@@ -15,82 +15,88 @@ import Synchronization
 extension PersistentSubscriptions {
     public final class Subscription<EventResult: SubscriptionEventResult>: Sendable {
         package typealias Request = PersistentSubscriptions.UnderlyingService.Method.Read.Input
-        
+
         private let source: (stream: AsyncThrowingStream<EventResult, Error>, continuation: AsyncThrowingStream<EventResult, Error>.Continuation)
         private let tracker: SubscriptionTracker
         private let writer: Writer
-        
+        private let _eventsCache: Mutex<AsyncThrowingStream<EventResult, Error>?> = .init(nil)
+
         public var subscriptionId: String? {
-            get{
-                tracker.subscriptionId
-            }
+            tracker.subscriptionId
         }
-        
-        public var events: AsyncThrowingStream<EventResult, Error>{
-            get{
+
+        public var lastRevision: UInt64? {
+            tracker.revision
+        }
+
+        public var lastPosition: StreamPosition? {
+            tracker.position
+        }
+
+        public var events: AsyncThrowingStream<EventResult, Error> {
+            _eventsCache.withLock { cache in
+                if let existing = cache {
+                    return existing
+                }
+
                 let (stream, continuation) = AsyncThrowingStream<EventResult, Error>.makeStream()
-                
-                let task = Task{
-                    do{
+
+                let task = Task {
+                    do {
                         for try await subscriptionResult in source.stream {
                             let result = continuation.yield(subscriptionResult)
                             if case .terminated = result {
                                 continuation.finish()
+                                return
                             }
                         }
                         continuation.finish()
-                    }catch{
+                    } catch {
                         continuation.finish(throwing: error)
                     }
                 }
-                
+
                 continuation.onTermination = { [writer, source, tracker] termination in
-                    // 不管 .finished 還是 .cancelled，都要通知 grpc 端停止
                     writer.stop()
                     source.continuation.finish()
                     task.cancel()
-                    tracker.finishAction?(termination)
+                    tracker.callFinishActionOnce(termination: termination)
                 }
-                
-                
+
+                cache = stream
                 return stream
             }
         }
-        
+
         init(writer: Writer) {
             self.writer = writer
             self.tracker = SubscriptionTracker()
             self.source = AsyncThrowingStream<EventResult, Error>.makeStream()
         }
-        
+
         internal func send(state: State) {
             switch state {
             case let .confirmation(subscriptionId):
                 tracker.update(subscriptionId: subscriptionId)
             case let .response(eventResult):
+                if let revision = eventResult.revision, let position = eventResult.position {
+                    tracker.update(revision: revision, position: position)
+                }
                 let result = source.continuation.yield(eventResult)
-                // ✅ 檢查 yield 結果
                 if case .terminated = result {
-                    // consumer 跑了，通知上游停止
                     source.continuation.finish()
                 }
             case let .finish(error):
                 source.continuation.finish(throwing: error)
             }
         }
-        
+
         internal func onFinish(perform action: @Sendable @escaping (_ termination: AsyncThrowingStream<EventResult, Error>.Continuation.Termination) -> Void) {
             tracker.update(action: action)
         }
-        
-        /// Acknowledges a list of events by their UUIDs.
-        ///
-        /// - Parameters:
-        ///   - eventIds: An array of `UUID` identifiers for the events to acknowledge.
-        /// - Throws: An error if the acknowledgment request fails.
+
         func ack(eventIds: [UUID]) async throws(KurrentError) {
             let usecase = PersistentSubscriptions.Ack(subscriptionId: subscriptionId, eventIds: eventIds)
-
             do {
                 let messages = try usecase.requestMessages()
                 writer.write(messages: messages)
@@ -99,38 +105,17 @@ extension PersistentSubscriptions {
             }
         }
 
-        /// Acknowledges a list of read events.
-        ///
-        /// This method extracts event IDs from the provided `ReadEvent` objects and calls `ack(eventIds:)`.
-        ///
-        /// - Parameter readEvents: An array of `ReadEvent` objects to acknowledge.
-        /// - Throws: An error if the acknowledgment process fails.
         public func ack(readEvents: [ReadEvent]) async throws(KurrentError) {
             let eventIds = readEvents.map {
-                if let link = $0.link {
-                    link.id
-                } else {
-                    $0.record.id
-                }
+                if let link = $0.link { link.id } else { $0.record.id }
             }
             try await ack(eventIds: eventIds)
         }
 
-        /// Acknowledges a variadic list of read events.
-        ///
-        /// - Parameter readEvents: A variadic list of `ReadEvent` objects to acknowledge.
-        /// - Throws: An error if the acknowledgment process fails.
         public func ack(readEvents: ReadEvent ...) async throws(KurrentError) {
             try await ack(readEvents: readEvents)
         }
 
-        /// Negatively acknowledges a list of events by their UUIDs.
-        ///
-        /// - Parameters:
-        ///   - eventIds: An array of `UUID` identifiers for the events to negatively acknowledge.
-        ///   - action: The action to take for the negatively acknowledged events.
-        ///   - reason: A string explaining why the events are negatively acknowledged.
-        /// - Throws: An error if the negative acknowledgment request fails.
         func nack(eventIds: [UUID], action: PersistentSubscriptions.Nack.Action, reason: String) async throws(KurrentError) {
             let usecase = PersistentSubscriptions.Nack(subscriptionId: subscriptionId, eventIds: eventIds, action: action, reason: reason)
             do {
@@ -141,103 +126,69 @@ extension PersistentSubscriptions {
             }
         }
 
-        /// Negatively acknowledges a list of read events.
-        ///
-        /// This method extracts event IDs from the provided `ReadEvent` objects and calls `nack(eventIds:action:reason:)`.
-        ///
-        /// - Parameters:
-        ///   - readEvents: An array of `ReadEvent` objects to negatively acknowledge.
-        ///   - action: The action to take for the negatively acknowledged events.
-        ///   - reason: A string explaining why the events are negatively acknowledged.
-        /// - Throws: An error if the negative acknowledgment process fails.
         public func nack(readEvents: [ReadEvent], action: PersistentSubscriptions.Nack.Action, reason: String) async throws(KurrentError) {
             let eventIds = readEvents.map {
-                if let link = $0.link {
-                    link.id
-                } else {
-                    $0.record.id
-                }
+                if let link = $0.link { link.id } else { $0.record.id }
             }
             try await nack(eventIds: eventIds, action: action, reason: reason)
         }
 
-        /// Negatively acknowledges a variadic list of read events.
-        ///
-        /// - Parameters:
-        ///   - readEvents: A variadic list of `ReadEvent` objects to negatively acknowledge.
-        ///   - action: The action to take for the negatively acknowledged events.
-        ///   - reason: A string explaining why the events are negatively acknowledged.
-        /// - Throws: An error if the negative acknowledgment process fails.
         public func nack(readEvents: ReadEvent ..., action: PersistentSubscriptions.Nack.Action, reason: String) async throws(KurrentError) {
             try await nack(readEvents: readEvents, action: action, reason: reason)
         }
     }
-    
-
 }
 
 
 extension PersistentSubscriptions.Subscription {
-    /// A utility struct for writing requests to the subscription service.
     package struct Writer {
-        /// The type of messages this writer handles.
         package typealias MessageType = Request
 
-        /// An asynchronous stream of messages to be sent.
         package let sender: AsyncStream<MessageType>
-
-        /// The continuation used to yield messages to the `sender` stream.
         package let continuation: AsyncStream<MessageType>.Continuation
 
-        /// Initializes a new writer with an asynchronous stream for sending messages.
         package init() {
             let (stream, continuation) = AsyncStream.makeStream(of: MessageType.self)
             sender = stream
             self.continuation = continuation
         }
 
-        /// Writes a variadic list of messages to the subscription service.
-        ///
-        /// - Parameter messages: A variadic list of messages to write.
         public func write(_ messages: MessageType...) {
             write(messages: messages)
         }
 
-        /// Writes an array of messages to the subscription service.
-        ///
-        /// - Parameter messages: An array of messages to write.
         public func write(messages: [MessageType]) {
             for message in messages {
                 continuation.yield(message)
             }
         }
 
-        /// Stops the writer by finishing the underlying stream.
         public func stop() {
             continuation.finish()
         }
     }
-    
+
     enum State: Sendable {
         case confirmation(subscriptionId: String)
         case response(eventResult: EventResult)
         case finish(throwing: (any Error)?)
-        
+
         internal static func finish() -> Self {
             .finish(throwing: nil)
         }
     }
-    
+
     private final class SubscriptionTracker: Sendable {
         private let _revision: Mutex<UInt64?> = .init(nil)
         private let _position: Mutex<StreamPosition?> = .init(nil)
         private let _subscriptionId: Mutex<String?> = .init(nil)
         private let _finishAction: Mutex<(@Sendable (_ termination: AsyncThrowingStream<EventResult, Error>.Continuation.Termination) -> Void)?> = .init(nil)
+        private let _hasFinished: Mutex<Bool> = .init(false)
 
         var subscriptionId: String? {
             _subscriptionId.withLock { $0 }
         }
-        
+
         var revision: UInt64? {
             _revision.withLock { $0 }
         }
@@ -245,15 +196,11 @@ extension PersistentSubscriptions.Subscription {
         var position: StreamPosition? {
             _position.withLock { $0 }
         }
-        
-        var finishAction: (@Sendable (_ termination: AsyncThrowingStream<EventResult, Error>.Continuation.Termination) -> Void)? {
-            _finishAction.withLock { $0 }
-        }
-        
+
         func update(subscriptionId: String) {
             _subscriptionId.withLock { $0 = subscriptionId }
         }
-        
+
         func update(action: @escaping @Sendable (_ termination: AsyncThrowingStream<EventResult, Error>.Continuation.Termination) -> Void) {
             _finishAction.withLock { $0 = action }
         }
@@ -261,6 +208,15 @@ extension PersistentSubscriptions.Subscription {
         func update(revision: UInt64, position: StreamPosition) {
             _revision.withLock { $0 = revision }
             _position.withLock { $0 = position }
+        }
+
+        func callFinishActionOnce(termination: AsyncThrowingStream<EventResult, Error>.Continuation.Termination) {
+            let action = _hasFinished.withLock { done -> (@Sendable (AsyncThrowingStream<EventResult, Error>.Continuation.Termination) -> Void)? in
+                guard !done else { return nil }
+                done = true
+                return _finishAction.withLock { $0 }
+            }
+            action?(termination)
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Cache bridge stream**: `events` 改為 lazy singleton — 第一次存取時建立橋接 `AsyncThrowingStream` 和 Task，後續每次存取回傳同一個 instance，確保 `source.stream` 同時只有一個 iterator
- **`finishAction` once-guard**: `SubscriptionTracker` 加入 `_hasFinished: Mutex<Bool>`，`callFinishActionOnce` 確保 completion handler 最多只被呼叫一次
- **Revision/Position tracking**: `send(state: .response)` 補上 `tracker.update(revision:position:)`，並新增 `public var lastRevision` / `public var lastPosition`
- **Bridge Task 提早退出**: `yield` 回傳 `.terminated` 時加上 `return`，避免繼續消耗 `source.stream`

## Test plan

- [ ] `swift build` 通過
- [ ] `swift test --filter PersistentSubscriptionsTests` — 訂閱收事件、ack/nack 正常運作
- [ ] `for await ... { break }` 後連線正確關閉（gRPC writer stopped）
- [ ] 多次存取 `subscription.events` 回傳同一個 stream instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription now exposes `lastRevision` and `lastPosition` properties for accessing current subscription state.

* **Improvements**
  * Events stream is now cached internally for improved performance on repeated access.
  * Enhanced stream termination handling to ensure proper cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->