### PR TITLE
[DOCS] Add comprehensive API documentation across all public modules

### DIFF
--- a/.github/workflows/swift-build-testing.yml
+++ b/.github/workflows/swift-build-testing.yml
@@ -29,6 +29,14 @@ jobs:
            swift-version: ${{ matrix.swift }}
       - run: ulimit -n 10000
 
+      - name: Login to Kurrent Docker Registry
+        if: startsWith(matrix.kurrentdb.image, 'docker.kurrent.io')
+        uses: docker/login-action@v3
+        with:
+          registry: docker.kurrent.io
+          username: ${{ secrets.KURRENT_DOCKER_USERNAME }}
+          password: ${{ secrets.KURRENT_DOCKER_PASSWORD }}
+
       - name: Start KurrentDB cluster
         run: KURRENTDB_IMAGE=${{ matrix.kurrentdb.image }} docker compose -f ${{ matrix.kurrentdb.compose_file }} up -d
 

--- a/.github/workflows/swift-build-testing.yml
+++ b/.github/workflows/swift-build-testing.yml
@@ -17,8 +17,8 @@ jobs:
         swift: ["6.0", "6.1", "6.2", "6.3"]
         kurrentdb:
           - { version: "24.10",  image: "docker.eventstore.com/eventstore/eventstoredb-ee:24.10", compose_file: "server/docker-compose.eventstore.yaml", supports_multi_streams: "false" }
-          - { version: "25.1",   image: "docker.kurrent.io/kurrent-latest/kurrentdb:25.1",            compose_file: "server/docker-compose.yaml",             supports_multi_streams: "true"  }
-          - { version: "26.0",   image: "docker.kurrent.io/kurrent-latest/kurrentdb:26.0",            compose_file: "server/docker-compose.yaml",             supports_multi_streams: "true"  }
+          - { version: "25.1",   image: "docker.eventstore.com/kurrent-latest/kurrentdb:25.1",            compose_file: "server/docker-compose.yaml",             supports_multi_streams: "true"  }
+          - { version: "26.0",   image: "docker.eventstore.com/kurrent-latest/kurrentdb:26.0",            compose_file: "server/docker-compose.yaml",             supports_multi_streams: "true"  }
     runs-on: ${{ matrix.os }}
     env:
       KURRENTDB_SUPPORTS_MULTI_STREAMS: ${{ matrix.kurrentdb.supports_multi_streams }}
@@ -28,14 +28,6 @@ jobs:
         with:
            swift-version: ${{ matrix.swift }}
       - run: ulimit -n 10000
-
-      - name: Login to Kurrent Docker Registry
-        if: startsWith(matrix.kurrentdb.image, 'docker.kurrent.io')
-        uses: docker/login-action@v3
-        with:
-          registry: docker.kurrent.io
-          username: ${{ secrets.KURRENT_DOCKER_USERNAME }}
-          password: ${{ secrets.KURRENT_DOCKER_PASSWORD }}
 
       - name: Start KurrentDB cluster
         run: KURRENTDB_IMAGE=${{ matrix.kurrentdb.image }} docker compose -f ${{ matrix.kurrentdb.compose_file }} up -d

--- a/Sources/KurrentDB/Core/ClientSettings/Authentication.swift
+++ b/Sources/KurrentDB/Core/ClientSettings/Authentication.swift
@@ -5,8 +5,11 @@
 //  Created by Grady Zhuo on 2025/3/24.
 //
 
+/// Authentication method used when connecting to a KurrentDB node.
 public enum Authentication: Sendable {
+    /// Username and password credentials (HTTP Basic auth).
     case credentials(username: String, password: String)
+    /// Mutual TLS authentication using a client certificate and private key.
     case x509(certFile: String, keyFile: String)
 
     package func makeBasicAuthHeader() throws(KurrentError) -> String {
@@ -24,6 +27,7 @@ public enum Authentication: Sendable {
 }
 
 extension Authentication: CustomStringConvertible {
+    /// Human-readable description of the authentication method.
     public var description: String {
         switch self {
         case .credentials(let username, _):

--- a/Sources/KurrentDB/Core/ClientSettings/ClientSettings.swift
+++ b/Sources/KurrentDB/Core/ClientSettings/ClientSettings.swift
@@ -16,82 +16,64 @@ import NIOSSL
 import NIOTransportServices
 import RegexBuilder
 
+/// Default TCP port number for KurrentDB connections.
 public let DEFAULT_PORT_NUMBER: UInt32 = 2113
 
-/// `ClientSettings` encapsulates various configuration settings for a client.
-///
-/// - Properties:
-///   - `configuration`: TLS configuration.
-///   - `clusterMode`: The cluster topology mode.
-///   - `secure`: Indicates if TLS is enabled (default is false).
-///   - `tlsVerifyCert`: Indicates if TLS certificate verification is enabled (default is false).
-///   - `defaultDeadline`: Default deadline for operations (default is `.max`).
-///   - `connectionName`: Optional connection name.
-///   - `keepAlive`: Keep-alive settings.
-///   - `defaultUserCredentials`: Optional user credentials.
-///
-/// - Initializers:
-///   - `init(clusterMode:configuration:numberOfThreads)`: Initializes with specified cluster mode, TLS configuration, and number of threads.
-///   - `init(clusterMode:numberOfThreads:configure)`: Initializes with specified cluster mode, number of threads, and TLS configuration using a configuration closure.
-///
-/// - Methods:
-///   - `makeCallOptions()`: Creates call options for making requests, optionally including user credentials.
-///
-/// - Static Methods:
-///   - `localhost(port:numberOfThreads:userCredentials:trustRoots)`: Returns settings configured for localhost with optional port, number of threads, user credentials, and trust roots.
-///   - `parse(connectionString)`: Parses a connection string into `ClientSettings`.
-///
-/// - Nested Types:
-///   - `TopologyClusterMode`: Defines the cluster topology modes.
-///   - `Endpoint`: Represents a network endpoint with a host and port.
-///
-/// - Conformance:
-///   - `ExpressibleByStringLiteral`: Allows initialization from a string literal.
-///
-/// - Example:
-///   - single node mode, initiating gRPC communication on the specified port on localhost and using 2 threads.
-///
-///   ```swift
-///   let clientSettingsSingleNode = ClientSettings(
-///       clusterMode: .singleNode(at: .init(host: "localhost", port: 50051)),
-///       configuration: .clientDefault,
-///       numberOfThreads: 2
-///   )
-///   ```
-///   - Gossip cluster mode, specifying multiple nodes' hosts and ports, as well as node preference and timeout, using 3 threads.
-///   ```swift
-///   let clientSettingsGossipCluster = ClientSettings(
-///       clusterMode: .gossipCluster(
-///           endpoints: [.init(host: "node1.example.com", port: 50051), .init(host: "node2.example.com", port: 50052)],
-///           nodePreference: .leader,
-///           timeout: 5.0
-///       ),
-///       configuration: .clientDefault,
-///       numberOfThreads: 3
-///   )
-///   ```
+/// Connection and transport configuration for a KurrentDB client.
 
 public struct ClientSettings: Sendable {
+    /// Resolved server endpoints derived from the cluster mode.
     public private(set) var endpoints: [Endpoint]
+    /// TLS certificate sources used to verify the server.
     public var certificates: [TLSConfig.CertificateSource]
 
+    /// Whether DNS-based cluster discovery is active.
     public private(set) var dnsDiscover: Bool
+    /// Preferred node role to connect to in a cluster.
     public private(set) var nodePreference: NodePreference
+    /// Maximum time allowed for a gossip request to complete.
     public private(set) var gossipTimeout: Duration
 
+    /// Whether TLS is enabled for the connection.
     public private(set) var secure: Bool
+    /// Whether server certificate verification is enforced when TLS is active.
     public private(set) var tlsVerifyCert: Bool
 
+    /// Default operation deadline in milliseconds; `.max` means no deadline.
     public private(set) var defaultDeadline: Int
+    /// Optional human-readable label for this connection.
     public private(set) var connectionName: String?
 
+    /// Keep-alive timing configuration for the gRPC channel.
     public var keepAlive: KeepAlive
+    /// Authentication credentials or certificate sent with each request.
     public var authentication: Authentication?
+    /// Interval between cluster node discovery polls.
     public var discoveryInterval: Duration
+    /// Maximum number of node discovery attempts before giving up.
     public var maxDiscoveryAttempts: UInt16
+    /// Duration for which a discovered node is cached before re-validation.
     public var nodeCacheTTL: Duration
+    /// Retry policy applied to operations that fail due to node-level errors.
     public var operationRetryPolicy: OperationRetryPolicy
 
+    /// Creates settings with explicit values for all configurable options.
+    ///
+    /// - Parameters:
+    ///   - clusterMode: Topology describing how to reach the server. Defaults to `nil` (no endpoint configured).
+    ///   - certificates: TLS certificate sources for server verification. Defaults to empty.
+    ///   - nodePreference: Preferred node role in a cluster. Defaults to `.leader`.
+    ///   - gossipTimeout: Timeout for gossip requests. Defaults to 3 seconds.
+    ///   - secure: Enables TLS. Defaults to `true`.
+    ///   - tlsVerifyCert: Enables certificate verification when TLS is active. Defaults to `true`.
+    ///   - defaultDeadline: Operation deadline in milliseconds. Defaults to `.max`.
+    ///   - connectionName: Optional label for this connection.
+    ///   - keepAlive: Keep-alive timing. Defaults to `.default`.
+    ///   - authentication: Credentials or certificate for authentication.
+    ///   - discoveryInterval: Interval between discovery polls. Defaults to 100 µs.
+    ///   - maxDiscoveryAttempts: Maximum discovery retries. Defaults to 10.
+    ///   - nodeCacheTTL: How long to cache a discovered node. Defaults to 30 seconds.
+    ///   - operationRetryPolicy: Retry behaviour for node-failure errors.
     public init(
         clusterMode: TopologyClusterMode? = nil,
         certificates: [TLSConfig.CertificateSource] = [],
@@ -149,6 +131,7 @@ public struct ClientSettings: Sendable {
 }
 
 extension ClientSettings {
+    /// Cluster topology derived from the current endpoints and discovery mode.
     public var clusterMode: TopologyClusterMode {
         if dnsDiscover {
             .dns(domain: endpoints[0])
@@ -159,6 +142,7 @@ extension ClientSettings {
         }
     }
 
+    /// TLS trust-roots source derived from `certificates`; `nil` when TLS is disabled.
     public var trustRoots: TLSConfig.TrustRootsSource? {
         guard secure else {
             return nil
@@ -170,6 +154,10 @@ extension ClientSettings {
         }
     }
 
+    /// Builds an HTTP or HTTPS URL for the given endpoint using the current security mode.
+    ///
+    /// - Parameter endpoint: The target endpoint.
+    /// - Returns: A `URL` for the endpoint, or `nil` if the URL components are invalid.
     public func httpUri(endpoint: Endpoint) -> URL? {
         var components = URLComponents()
         components.scheme = secure ? "https" : "http"
@@ -180,10 +168,22 @@ extension ClientSettings {
 }
 
 extension ClientSettings {
+    /// Returns settings targeting a single insecure KurrentDB node on `localhost:2113`.
+    ///
+    /// ```swift
+    /// let settings = ClientSettings.localhost()
+    ///     .authenticated(.credentials(username: "admin", password: "changeit"))
+    /// ```
+    ///
+    /// - Returns: Insecure `ClientSettings` for `localhost` on the default port.
     public static func localhost() -> Self {
         localhost(ports: DEFAULT_PORT_NUMBER)
     }
 
+    /// Returns insecure settings targeting one or more ports on `localhost`.
+    ///
+    /// - Parameter ports: One or more port numbers. Multiple ports produce a seed-cluster topology.
+    /// - Returns: Insecure `ClientSettings` for the given `localhost` ports.
     public static func localhost(ports: UInt32...) -> Self {
         let endpoints: [Endpoint] = ports.map { .init(host: "localhost", port: $0) }
         let clusterMode: TopologyClusterMode = if endpoints.count == 1 {
@@ -194,6 +194,12 @@ extension ClientSettings {
         return Self(clusterMode: clusterMode, secure: false, tlsVerifyCert: false)
     }
 
+    /// Returns settings targeting one or more remote endpoints.
+    ///
+    /// - Parameters:
+    ///   - endpoints: One or more server endpoints. Multiple endpoints produce a seed-cluster topology.
+    ///   - secure: Enables TLS. Defaults to `true`.
+    /// - Returns: `ClientSettings` configured for the provided remote endpoints.
     public static func remote(_ endpoints: Endpoint..., secure: Bool = true) -> Self {
         let clusterMode: TopologyClusterMode = if endpoints.count == 1 {
             .standalone(endpoint: endpoints[0])
@@ -203,6 +209,22 @@ extension ClientSettings {
         return Self(clusterMode: clusterMode, secure: secure)
     }
 
+    /// Parses a KurrentDB connection string into `ClientSettings`.
+    ///
+    /// Supported schemes are `esdb://` and `esdb+discover://`. Recognised query parameters include
+    /// `tls`, `tlsVerifyCert`, `nodePreference`, `keepAliveInterval` and `keepAliveTimeout` (both
+    /// required for either to take effect), `gossipTimeout`, `maxDiscoverAttempts`, `discoveryInterval`,
+    /// `userCertFile`, `userKeyFile`, `connectionName`, `tlsCaFile`, and `defaultDeadline`.
+    ///
+    /// ```swift
+    /// let settings = try ClientSettings.parse(
+    ///     connectionString: "esdb://admin:changeit@localhost:2113?tls=false"
+    /// )
+    /// ```
+    ///
+    /// - Parameter connectionString: A well-formed KurrentDB connection string.
+    /// - Returns: Fully populated `ClientSettings`.
+    /// - Throws: `KurrentError.internalParsingError` if the string is malformed or missing required components.
     public static func parse(connectionString: String) throws(KurrentError) -> Self {
         let schemeParser = URLSchemeParser()
         let endpointParser = EndpointParser()
@@ -299,6 +321,13 @@ extension ClientSettings {
 }
 
 extension ClientSettings {
+    /// Loads a TLS CA certificate from disk and returns the appropriate source.
+    ///
+    /// Detects PEM format automatically by inspecting the file header; falls back to DER.
+    /// Returns `nil` and logs a warning if the file is missing or empty.
+    ///
+    /// - Parameter path: File-system path to the CA certificate.
+    /// - Returns: A `TLSConfig.CertificateSource` for the file, or `nil` on failure.
     public static func parseCertificate(path: String) -> TLSConfig.CertificateSource? {
         do {
             let tlsCaFileUrl = URL(fileURLWithPath: path)
@@ -326,8 +355,14 @@ extension ClientSettings {
 }
 
 extension ClientSettings: ExpressibleByStringLiteral {
+    /// String literal type for `ExpressibleByStringLiteral` conformance.
     public typealias StringLiteralType = String
 
+    /// Creates `ClientSettings` by parsing a KurrentDB connection string literal.
+    ///
+    /// - Parameter value: A well-formed KurrentDB connection string (e.g. `"esdb://localhost:2113"`).
+    ///
+    /// > Important: Calls `fatalError` if `value` is not a valid connection string.
     public init(stringLiteral value: String) {
         do {
             self = try Self.parse(connectionString: value)
@@ -343,6 +378,9 @@ extension ClientSettings: ExpressibleByStringLiteral {
 }
 
 extension ClientSettings: Buildable {
+    /// Returns a copy with the given certificate source appended.
+    ///
+    /// - Parameter source: The certificate source to add.
     @discardableResult
     public func certificate(source: TLSConfig.CertificateSource) -> Self {
         withCopy {
@@ -350,6 +388,9 @@ extension ClientSettings: Buildable {
         }
     }
 
+    /// Returns a copy with a certificate loaded from the given file path appended.
+    ///
+    /// - Parameter path: File-system path to the certificate file.
     @discardableResult
     public func certificate(path: String) -> Self {
         withCopy {
@@ -359,24 +400,30 @@ extension ClientSettings: Buildable {
         }
     }
 
+    /// Deprecated. Use ``certificates`` instead.
     @available(*, deprecated, renamed: "certificates")
     public var cerificates: [TLSConfig.CertificateSource] {
         get { certificates }
         set { certificates = newValue }
     }
 
+    /// Deprecated. Use ``certificate(source:)`` instead.
     @available(*, deprecated, renamed: "certificate(source:)")
     @discardableResult
     public func cerificate(source: TLSConfig.CertificateSource) -> Self {
         certificate(source: source)
     }
 
+    /// Deprecated. Use ``certificate(path:)`` instead.
     @available(*, deprecated, renamed: "certificate(path:)")
     @discardableResult
     public func cerificate(path: String) -> Self {
         certificate(path: path)
     }
 
+    /// Returns a copy with TLS enabled or disabled.
+    ///
+    /// - Parameter secure: Pass `true` to enable TLS, `false` for plaintext.
     @discardableResult
     public func secure(_ secure: Bool) -> Self {
         withCopy {
@@ -384,6 +431,9 @@ extension ClientSettings: Buildable {
         }
     }
 
+    /// Returns a copy with certificate verification enabled or disabled.
+    ///
+    /// - Parameter tlsVerifyCert: Pass `true` to enforce full certificate verification.
     @discardableResult
     public func tlsVerifyCert(_ tlsVerifyCert: Bool) -> Self {
         withCopy {
@@ -391,6 +441,9 @@ extension ClientSettings: Buildable {
         }
     }
 
+    /// Returns a copy with the default operation deadline set.
+    ///
+    /// - Parameter defaultDeadline: Deadline in milliseconds; use `.max` for no deadline.
     @discardableResult
     public func defaultDeadline(_ defaultDeadline: Int) -> Self {
         withCopy {
@@ -398,6 +451,9 @@ extension ClientSettings: Buildable {
         }
     }
 
+    /// Returns a copy with the given connection name set.
+    ///
+    /// - Parameter connectionName: Human-readable label for this connection.
     @discardableResult
     public func connectionName(_ connectionName: String) -> Self {
         withCopy {
@@ -405,6 +461,9 @@ extension ClientSettings: Buildable {
         }
     }
 
+    /// Returns a copy with the given keep-alive settings applied.
+    ///
+    /// - Parameter keepAlive: Keep-alive interval and timeout configuration.
     @discardableResult
     public func keepAlive(_ keepAlive: KeepAlive) -> Self {
         withCopy {
@@ -412,6 +471,9 @@ extension ClientSettings: Buildable {
         }
     }
 
+    /// Returns a copy with the given authentication applied.
+    ///
+    /// - Parameter authenication: Credentials or certificate used for authentication.
     @discardableResult
     public func authenticated(_ authenication: Authentication) -> Self {
         withCopy {
@@ -419,6 +481,9 @@ extension ClientSettings: Buildable {
         }
     }
 
+    /// Returns a copy with the cluster discovery interval set.
+    ///
+    /// - Parameter discoveryInterval: Time between consecutive discovery polls.
     @discardableResult
     public func discoveryInterval(_ discoveryInterval: Duration) -> Self {
         withCopy {
@@ -426,6 +491,9 @@ extension ClientSettings: Buildable {
         }
     }
 
+    /// Returns a copy with the maximum discovery attempts set.
+    ///
+    /// - Parameter maxDiscoveryAttempts: Upper limit on node-discovery retries.
     @discardableResult
     public func maxDiscoveryAttempts(_ maxDiscoveryAttempts: UInt16) -> Self {
         withCopy {
@@ -433,6 +501,9 @@ extension ClientSettings: Buildable {
         }
     }
 
+    /// Returns a copy with the node cache TTL set.
+    ///
+    /// - Parameter ttl: Duration for which a discovered node is cached before re-validation.
     @discardableResult
     public func nodeCacheTTL(_ ttl: Duration) -> Self {
         withCopy {
@@ -440,6 +511,9 @@ extension ClientSettings: Buildable {
         }
     }
 
+    /// Returns a copy with the operation retry policy set.
+    ///
+    /// - Parameter policy: Retry behaviour applied to node-failure errors.
     @discardableResult
     public func operationRetryPolicy(_ policy: OperationRetryPolicy) -> Self {
         withCopy {

--- a/Sources/KurrentDB/Core/ClientSettings/Endpoint.swift
+++ b/Sources/KurrentDB/Core/ClientSettings/Endpoint.swift
@@ -8,28 +8,41 @@
 import GRPCNIOTransportCore
 import NIO
 
+/// Network address of a single KurrentDB node, expressed as a host and port pair.
+///
+/// Endpoints can be created from string literals for convenience:
+///
+/// ```swift
+/// let endpoint: Endpoint = "db.example.com:2113"
+/// let defaultPort: Endpoint = "db.example.com"  // port defaults to 2113
+/// ```
 public struct Endpoint: Sendable {
+    /// DNS name or IP address of the server.
     let host: String
+    /// TCP port the server is listening on.
     let port: UInt32
 
+    /// Creates an endpoint with an explicit host and optional port.
+    ///
+    /// - Parameters:
+    ///   - host: DNS name or IP address of the server.
+    ///   - port: TCP port number. Defaults to `DEFAULT_PORT_NUMBER` (2113) when `nil`.
     public init(host: String, port: UInt32? = nil) {
         self.host = host
         self.port = port ?? DEFAULT_PORT_NUMBER
     }
 
+    /// Returns `true` when the host resolves to the local machine.
     public var isLocalhost: Bool {
         ["127.0.0.1", "localhost"].contains(host)
     }
 }
 
 extension Endpoint {
-    /// Initializes an `Endpoint` from a string in the format `"host:port"` or `"host"`.
+    /// Creates an `Endpoint` by parsing a `"host"` or `"host:port"` string.
     ///
-    /// - `"db.example.com:2113"` → host: `db.example.com`, port: `2113`
-    /// - `"db.example.com"` → host: `db.example.com`, port: `2113` (default)
-    /// - `"127.0.0.1:2114"` → host: `127.0.0.1`, port: `2114`
-    ///
-    /// Returns `nil` if the string is empty.
+    /// - Parameter string: A non-empty string in `"host"` or `"host:port"` format.
+    /// - Returns: A configured `Endpoint`, or `nil` if `string` is empty.
     public init?(string: String) {
         let parts = string.split(separator: ":", maxSplits: 1)
         guard let host = parts.first.map(String.init) else {
@@ -45,6 +58,11 @@ extension Endpoint {
 }
 
 extension Endpoint: ExpressibleByStringLiteral {
+    /// Creates an `Endpoint` from a `"host"` or `"host:port"` string literal.
+    ///
+    /// - Parameter value: A string in `"host"` or `"host:port"` format.
+    ///
+    /// > Important: Calls `preconditionFailure` if `value` is empty or malformed.
     public init(stringLiteral value: String) {
         guard let endpoint = Endpoint(string: value) else {
             preconditionFailure("Invalid endpoint string literal: \"\(value)\". Expected format: \"host\" or \"host:port\".")
@@ -54,24 +72,30 @@ extension Endpoint: ExpressibleByStringLiteral {
 }
 
 extension Endpoint: Equatable {
+    /// Returns true if both endpoints have the same host and port.
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.host == rhs.host && lhs.port == rhs.port
     }
 }
 
 extension Endpoint: CustomStringConvertible {
+    /// Human-readable representation in the form `Endpoint(host:port)`.
     public var description: String {
         "\(Self.self)(\(host):\(port))"
     }
 }
 
 extension Endpoint: CustomDebugStringConvertible {
+    /// Compact `host:port` string, suitable for logging and debugging.
     public var debugDescription: String {
         "\(host):\(port)"
     }
 }
 
 extension Endpoint {
+    /// Resolves the endpoint to an NIO `ResolvableTarget`, choosing IPv4, IPv6, or DNS as appropriate.
+    ///
+    /// The current implementation always succeeds; the `throws` signature is retained for future compatibility.
     public var target: ResolvableTarget {
         get throws {
             let port = Int(port)

--- a/Sources/KurrentDB/Core/ClientSettings/KeepAlive.swift
+++ b/Sources/KurrentDB/Core/ClientSettings/KeepAlive.swift
@@ -7,17 +7,29 @@
 
 import Foundation
 
+/// gRPC keep-alive timing configuration for a KurrentDB connection.
 public struct KeepAlive: Sendable {
+    /// Default keep-alive settings: 10-second interval and 10-second timeout.
     public static let `default`: Self = .init(interval: .seconds(10), timeout: .seconds(10))
 
     var interval: Duration
     var timeout: Duration
 
+    /// Creates keep-alive settings with `Duration` values.
+    ///
+    /// - Parameters:
+    ///   - interval: Time between keep-alive pings.
+    ///   - timeout: Time to wait for a keep-alive acknowledgment before closing the connection.
     init(interval: Duration, timeout: Duration) {
         self.interval = interval
         self.timeout = timeout
     }
 
+    /// Creates keep-alive settings from millisecond integer values.
+    ///
+    /// - Parameters:
+    ///   - interval: Ping interval in milliseconds.
+    ///   - timeout: Acknowledgment timeout in milliseconds.
     init(intervalMs interval: UInt64, timeoutMs timeout: UInt64) {
         self.interval = .milliseconds(interval)
         self.timeout = .milliseconds(timeout)

--- a/Sources/KurrentDB/Core/ClientSettings/NodePreference.swift
+++ b/Sources/KurrentDB/Core/ClientSettings/NodePreference.swift
@@ -5,10 +5,15 @@
 //  Created by Grady Zhuo on 2025/5/3.
 //
 
+/// Preferred cluster node role to connect to when multiple nodes are available.
 public enum NodePreference: String, Sendable {
+    /// Prefer the cluster leader for all operations.
     case leader
+    /// Prefer a follower node, falling back to leader if none is available.
     case follower
+    /// Select any available node at random.
     case random
+    /// Prefer a read-only replica, falling back to other node types if unavailable.
     case readOnlyReplica = "readonlyreplica"
 }
 

--- a/Sources/KurrentDB/Core/ClientSettings/TopologyClusterMode.swift
+++ b/Sources/KurrentDB/Core/ClientSettings/TopologyClusterMode.swift
@@ -8,8 +8,12 @@
 import Foundation
 import NIOCore
 
+/// Cluster topology mode describing how the client discovers and connects to KurrentDB nodes.
 public enum TopologyClusterMode: Sendable {
+    /// Single-node topology connecting directly to one endpoint.
     case standalone(endpoint: Endpoint)
+    /// DNS-based discovery using a single domain endpoint to locate cluster members.
     case dns(domain: Endpoint)
+    /// Gossip-based discovery using a known list of seed endpoints.
     case seeds([Endpoint])
 }

--- a/Sources/KurrentDB/Core/Cursor/PositionCursor.swift
+++ b/Sources/KurrentDB/Core/Cursor/PositionCursor.swift
@@ -5,15 +5,19 @@
 //  Created by Grady Zhuo on 2025/3/25.
 //
 
+/// Starting position for reading from the `$all` stream.
 public enum PositionCursor: Sendable {
+    /// Begins reading from the very first event in the stream.
     case start
+    /// Begins reading from the most recent event in the stream.
     case end
+    /// Begins reading at the explicit commit and prepare log positions.
     case specified(commit: UInt64, prepare: UInt64)
 
-    /// Returns a `specified` position cursor with both `commit` and `prepare` set to the given value.
+    /// Creates a `specified` cursor with both `commit` and `prepare` set to the same value.
     ///
-    /// - Parameter commit: The value to use for both the `commit` and `prepare` positions.
-    /// - Returns: A `PositionCursor.specified` case with identical `commit` and `prepare` values.
+    /// - Parameter commit: Value used for both the commit and prepare positions.
+    /// - Returns: A `PositionCursor.specified` case with identical commit and prepare positions.
     public static func specified(commit: UInt64) -> Self {
         .specified(commit: commit, prepare: commit)
     }

--- a/Sources/KurrentDB/Core/Cursor/RevisionCursor.swift
+++ b/Sources/KurrentDB/Core/Cursor/RevisionCursor.swift
@@ -5,11 +5,19 @@
 //  Created by Grady Zhuo on 2025/3/25.
 //
 
+/// Starting revision for reading from a named stream.
 public enum RevisionCursor: Sendable {
+    /// Begins reading from the first event (revision 0).
     case start
+    /// Begins reading from the most recently written event.
     case end
+    /// Begins reading at the explicit event revision number.
     case specified(UInt64)
-    
+
+    /// Creates a `specified` cursor at the given revision number.
+    ///
+    /// - Parameter revision: The event revision number to start from.
+    /// - Returns: A `RevisionCursor.specified` case wrapping the given revision.
     public static func from(_ revision: UInt64) -> RevisionCursor {
         .specified(revision)
     }

--- a/Sources/KurrentDB/Core/Direction.swift
+++ b/Sources/KurrentDB/Core/Direction.swift
@@ -5,7 +5,10 @@
 //  Created by Grady Zhuo on 2025/3/25.
 //
 
+/// Read direction for stream traversal operations.
 public enum Direction: Sendable {
+    /// Reads events from oldest to newest.
     case forward
+    /// Reads events from newest to oldest.
     case backward
 }

--- a/Sources/KurrentDB/Core/Error/KurrentError+RevisionOption.swift
+++ b/Sources/KurrentDB/Core/Error/KurrentError+RevisionOption.swift
@@ -6,15 +6,23 @@
 //
 
 extension KurrentError {
+    /// The actual stream revision returned by the server when a version conflict occurs.
     public enum CurrentRevisionOption: Sendable {
+        /// The stream does not exist on the server.
         case noStream
+        /// The stream exists at the given revision number.
         case revision(UInt64)
     }
 
+    /// The revision expectation provided by the caller when appending events.
     public enum ExpectedRevisionOption: Sendable {
+        /// No revision constraint — append succeeds regardless of current state.
         case any
+        /// The stream must already exist; fails if the stream has not been created.
         case streamExists
+        /// The stream must not exist; fails if the stream already has events.
         case noStream
+        /// The stream must be at exactly this revision number.
         case revision(UInt64)
     }
 }

--- a/Sources/KurrentDB/Core/Error/KurrentError+WrongExpectedVersion.swift
+++ b/Sources/KurrentDB/Core/Error/KurrentError+WrongExpectedVersion.swift
@@ -8,6 +8,7 @@
 import GRPCEncapsulates
 
 extension KurrentError {
+    /// Converts a protobuf `WrongExpectedVersion` response into a ``KurrentError/wrongExpectedVersion(expected:current:)`` case.
     package static func wrongExpectedVersion(_ wrongResult: EventStore_Client_Streams_AppendResp.WrongExpectedVersion) -> Self {
         let expectedRevision: ExpectedRevisionOption = wrongResult.expectedRevisionOption.map {
             switch $0 {

--- a/Sources/KurrentDB/Core/Error/KurrentError.swift
+++ b/Sources/KurrentDB/Core/Error/KurrentError.swift
@@ -11,29 +11,53 @@ import GRPCEncapsulates
 import GRPCProtobuf
 import NIO
 
+/// Errors thrown by KurrentDB client operations.
 public enum KurrentError: Error, Sendable {
+    /// The server returned an error message not mapped to a specific case.
     case serverError(String)
+    /// A leader-only command was sent to a follower node.
     case notLeaderException
+    /// The gRPC connection was closed before the operation completed.
     case connectionClosed
+    /// An unmapped gRPC status code was received from the server.
     case grpc(code: GoogleRPCStatus?, reason: String)
+    /// A gRPC-level error occurred that is not mapped to a domain-specific case.
     case grpcError(cause: RPCError)
+    /// A gRPC runtime error occurred outside of a specific RPC call.
     case grpcRuntimeError(cause: RuntimeError)
+    /// The underlying transport connection to the server failed.
     case grpcConnectionError(cause: RPCError)
+    /// An internal error occurred while parsing a server response.
     case internalParsingError(reason: String)
+    /// The caller does not have permission to perform the requested operation.
     case accessDenied
+    /// The resource (stream, projection, subscription) already exists.
     case resourceAlreadyExists
+    /// The requested resource was not found on the server.
     case resourceNotFound(reason: String)
+    /// The requested stream or resource has been deleted.
     case resourceDeleted(resource: String)
+    /// A linked event could not be resolved, typically because it was deleted.
     case unservicableEventLink(link: RecordedEvent)
+    /// The server does not support the requested gRPC method.
     case unsupportedFeature(GRPCCore.MethodDescriptor)
+    /// An unexpected client-side error occurred; please file an issue on GitHub.
     case internalClientError(reason: String)
+    /// The operation deadline was exceeded before the server responded.
     case deadlineExceeded
+    /// Client initialization failed before any request could be made.
     case initializationError(reason: String)
+    /// The client or server is in an invalid state for the requested operation.
     case illegalStateError(reason: String)
+    /// The append was rejected because the stream revision did not match the expectation.
     case wrongExpectedVersion(expected: ExpectedRevisionOption, current: CurrentRevisionOption)
+    /// The subscription was terminated by an explicit user call.
     case subscriptionTerminated(subscriptionId: String?)
+    /// The server dropped the subscription unexpectedly.
     case subscriptionDropped(reason: String, lastRevision: UInt64?, lastPosition: StreamPosition?)
+    /// A string could not be encoded using the specified encoding.
     case encodingError(message: String, encoding: String.Encoding)
+    /// A value could not be decoded from the server response.
     case decodingError(cause: DecodingError)
 }
 

--- a/Sources/KurrentDB/Core/Event/ContentType.swift
+++ b/Sources/KurrentDB/Core/Event/ContentType.swift
@@ -7,8 +7,12 @@
 
 import Foundation
 
+/// MIME content type for event data payloads.
 public enum ContentType: String, Codable, Sendable {
+    /// Content type is not specified or unrecognised.
     case unknown
+    /// JSON-encoded payload (`application/json`).
     case json = "application/json"
+    /// Raw binary payload (`application/octet-stream`).
     case binary = "application/octet-stream"
 }

--- a/Sources/KurrentDB/Core/Event/EventData.swift
+++ b/Sources/KurrentDB/Core/Event/EventData.swift
@@ -8,14 +8,37 @@
 import Foundation
 import GRPCEncapsulates
 
+/// Event payload prepared for appending to a KurrentDB stream.
 public struct EventData: EventStoreEvent {
+    /// Unique identifier for this event.
     public private(set) var id: UUID
+
+    /// Logical type name describing the event's schema.
     public private(set) var eventType: String
+
+    /// Encoded payload and its content type.
     public private(set) var payload: Payload
+
+    /// Optional opaque metadata bytes attached to the event.
     public private(set) var customMetadata: Data?
 
+    /// gRPC metadata headers derived from `payload` and `eventType`.
     public private(set) var metadata: [String: String]
 
+    /// Creates an event with an explicit `Payload` value.
+    ///
+    /// ```swift
+    /// let event = EventData(
+    ///     eventType: "order-placed",
+    ///     payload: .json(OrderPlaced(id: "123"))
+    /// )
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - id: Unique event identifier; defaults to a new random UUID.
+    ///   - eventType: Logical schema name for the event.
+    ///   - payload: Encoded content and its content type.
+    ///   - customMetadata: Optional raw metadata bytes appended alongside the event.
     public init(id: UUID = .init(), eventType: String, payload: Payload, customMetadata: Data? = nil) {
         self.id = id
         self.eventType = eventType
@@ -33,24 +56,52 @@ public struct EventData: EventStoreEvent {
         self.init(id: id, eventType: eventType, payload: .json(payload), customMetadata: customMetadata)
     }
 
+    /// Creates an event from a `Codable` model, encoding it as JSON.
+    ///
+    /// - Parameters:
+    ///   - id: Unique event identifier; defaults to a new random UUID.
+    ///   - eventType: Logical schema name for the event.
+    ///   - model: Codable model to encode as the event payload.
+    ///   - customMetadata: Optional raw metadata bytes appended alongside the event.
     public init(id: UUID = .init(), eventType: String, model: Codable & Sendable, customMetadata: Data? = nil) {
         self.init(id: id, eventType: eventType, payload: .json(model), customMetadata: customMetadata)
     }
 
+    /// Creates an event from pre-encoded `Data` with an explicit content type.
+    ///
+    /// - Parameters:
+    ///   - id: Unique event identifier; defaults to a new random UUID.
+    ///   - eventType: Logical schema name for the event.
+    ///   - data: Pre-serialized event payload bytes.
+    ///   - contentType: Content type describing the encoding; defaults to `.json`.
+    ///   - customMetadata: Optional raw metadata bytes appended alongside the event.
     public init(id: UUID = .init(), eventType: String, data: Data, contentType: ContentType = .json, customMetadata: Data? = nil) {
         self.init(id: id, eventType: eventType, payload: .data(data, contentType), customMetadata: customMetadata)
     }
 
+    /// Creates an event from a raw byte array with an explicit content type.
+    ///
+    /// - Parameters:
+    ///   - id: Unique event identifier; defaults to a new random UUID.
+    ///   - eventType: Logical schema name for the event.
+    ///   - bytes: Raw payload bytes.
+    ///   - contentType: Content type describing the encoding; defaults to `.json`.
+    ///   - customMetadata: Optional raw metadata bytes appended alongside the event.
     public init(id: UUID = .init(), eventType: String, bytes: [UInt8], contentType: ContentType = .json, customMetadata: Data? = nil) {
         self.init(id: id, eventType: eventType, data: .init(bytes), contentType: contentType, customMetadata: customMetadata)
     }
 }
 
 extension EventData {
+    /// Typed container for an event's raw bytes or Codable model payload.
     public enum Payload: Sendable {
+        /// Pre-encoded bytes with an explicit content type.
         case data(Data, ContentType)
+
+        /// A Codable model that will be JSON-encoded on demand.
         case json(Codable & Sendable)
 
+        /// Content type of the payload.
         public var contentType: ContentType {
             switch self {
             case let .data(_, contentType):
@@ -60,6 +111,7 @@ extension EventData {
             }
         }
 
+        /// Serialized bytes of the payload; throws if JSON encoding fails.
         public var data: Data {
             get throws {
                 switch self {
@@ -74,12 +126,21 @@ extension EventData {
 }
 
 extension EventData {
+    /// Creates a new `EventData` by copying the type, payload, and metadata from a `RecordedEvent`.
+    ///
+    /// - Parameters:
+    ///   - id: Unique event identifier for the new event; defaults to a new random UUID.
+    ///   - recordedEvent: The recorded event whose payload and metadata are copied.
     public init(id: UUID = .init(), like recordedEvent: RecordedEvent) {
         self.init(id: id, eventType: recordedEvent.eventType, data: recordedEvent.data, customMetadata: recordedEvent.customMetadata)
     }
 }
 
 extension EventRecord {
+    /// Creates an `EventRecord` from an `EventData` value, bridging the legacy API to the newer record type.
+    ///
+    /// - Parameter eventData: The source event data to convert.
+    /// - Throws: `KurrentError` if the payload cannot be encoded.
     public init(eventData: EventData) throws {
         let payload: Payload = switch eventData.payload {
         case let .data(data, contentType):

--- a/Sources/KurrentDB/Core/Event/EventData.swift
+++ b/Sources/KurrentDB/Core/Event/EventData.swift
@@ -140,7 +140,7 @@ extension EventRecord {
     /// Creates an `EventRecord` from an `EventData` value, bridging the legacy API to the newer record type.
     ///
     /// - Parameter eventData: The source event data to convert.
-    /// - Throws: `KurrentError` if the payload cannot be encoded.
+    /// - Throws: `EncodingError` if the payload cannot be JSON-encoded.
     public init(eventData: EventData) throws {
         let payload: Payload = switch eventData.payload {
         case let .data(data, contentType):

--- a/Sources/KurrentDB/Core/Event/EventRecord.swift
+++ b/Sources/KurrentDB/Core/Event/EventRecord.swift
@@ -51,7 +51,7 @@ extension EventRecord {
     ///   - eventType: Logical schema name set as `schema.name` (e.g., `"order-placed"`).
     ///   - payload: Typed payload; its format is inferred and used to populate `schema.format`.
     ///   - customMetadata: Optional JSON bytes parsed into `properties`; keys starting with `$` are system-reserved.
-    /// - Throws: `KurrentError` if JSON encoding or metadata parsing fails.
+    /// - Throws: `EncodingError` if the payload cannot be JSON-encoded, or `Error` if metadata parsing fails.
     public init(id: UUID? = nil, eventType: String, payload: Payload, customMetadata: Data? = nil) throws {
         let schema = Schema(format: payload.format, name: eventType)
         let properties = try customMetadata.flatMap {

--- a/Sources/KurrentDB/Core/Event/EventRecord.swift
+++ b/Sources/KurrentDB/Core/Event/EventRecord.swift
@@ -7,62 +7,27 @@
 import Foundation
 import GRPCEncapsulates
 
+/// Structured event payload prepared for appending to a KurrentDB stream.
 public struct EventRecord: Sendable {
-    /// Unique identifier for this record (must be a valid UUID/GUID).
-    /// If not provided, the server will generate a new one.
+    /// Optional unique identifier; when `nil` the server assigns one on write.
     public let id: UUID?
 
-    /// The record payload as raw bytes.
-    /// The format specified in SchemaInfo determines how to interpret these bytes.
+    /// Raw payload bytes whose encoding is described by `schema`.
     public let data: Data
 
-    /// Schema information for this record.
+    /// Schema metadata describing how to interpret `data`.
     public let schema: Schema
 
-    /// A collection of properties providing additional information about the
-    /// record. Can contain user-defined or system propreties.
-    /// System keys will be prefixed with "$" (e.g., "$timestamp").
-    /// User-defined keys MUST NOT start with "$".
-    ///
-    /// Common examples:
-    ///   User metadata:
-    ///     - "user-id": "12345"
-    ///     - "tenant": "acme-corp"
-    ///     - "source": "mobile-app"
-    ///
-    ///   System metadata (with $ prefix):
-    ///     - "$trace-id": "4bf92f3577b34da6a3ce929d0e0e4736"  // OpenTelemetry trace ID
-    ///     - "$span-id": "00f067aa0ba902b7"                   // OpenTelemetry span ID
-    ///     - "$timestamp": "2025-01-15T10:30:00.000Z"         // ISO 8601 timestamp
+    /// Arbitrary key-value metadata; keys prefixed with `$` are system-reserved.
     public var properties: [String: Codable & Sendable]
 
-    /// Initializes a new event record with an optional identifier, raw payload data,
-    /// schema metadata, and associated properties.
-    ///
-    /// Use this initializer to create a record that can be appended to a stream or
-    /// persisted in storage. The `schema` describes how to interpret the raw `data`,
-    /// while `properties` carries metadata such as tracing information, timestamps,
-    /// or user-defined attributes.
+    /// Creates a record from raw bytes, schema metadata, and optional properties.
     ///
     /// - Parameters:
-    ///   - id: An optional unique identifier (UUID/GUID) for the record. If `nil`,
-    ///     the server or storage layer may generate an identifier when the record is
-    ///     persisted.
-    ///   - data: The raw payload bytes for the record. Interpretation of these bytes
-    ///     is defined by the provided `schema`.
-    ///   - schema: Schema metadata describing the encoding format (e.g., JSON, Protobuf)
-    ///     and logical schema name (and optionally a specific schema/version identifier)
-    ///     for the payload data.
-    ///   - properties: A dictionary of additional metadata associated with the record.
-    ///     Keys prefixed with "$" are reserved for system properties (e.g., "$trace-id",
-    ///     "$span-id", "$timestamp"). User-defined keys must not start with "$".
-    ///     Values must be `Codable`.
-    ///
-    /// - Important: Ensure that `schema.format` matches the actual encoding of `data`.
-    ///   When using system-reserved properties (keys starting with "$"), avoid collisions
-    ///   with user-defined keys.
-    ///
-    /// - SeeAlso: `EventRecord.SchemaInfo`, `EventRecord.SchemaInfo.SchemaFormat`
+    ///   - id: Optional unique identifier; defaults to `nil` so the server can assign one.
+    ///   - data: Raw payload bytes whose encoding matches `schema.format`.
+    ///   - schema: Schema metadata describing the payload's format and name.
+    ///   - properties: Additional key-value metadata; keys starting with `$` are system-reserved.
     public init(id: UUID? = nil, data: Data, schema: Schema, properties: [String: Codable & Sendable] = [:]) {
         self.id = id
         self.data = data
@@ -72,43 +37,21 @@ public struct EventRecord: Sendable {
 }
 
 extension EventRecord {
-    /// Convenience initializer to create an EventRecord from a semantic event type, a typed payload,
-    /// and optional custom metadata bytes.
+    /// Creates a record from a logical event type and typed payload, inferring the schema format automatically.
     ///
-    /// This initializer helps you build an EventRecord without manually assembling SchemaInfo or
-    /// encoding metadata dictionaries. It derives the schema format from the provided payload and
-    /// attempts to parse custom metadata when present.
+    /// ```swift
+    /// let record = try EventRecord(
+    ///     eventType: "order-placed",
+    ///     payload: .json(OrderPlaced(id: "123", total: 42.0))
+    /// )
+    /// ```
     ///
-    /// Parameters:
-    /// - id: An optional unique identifier (UUID/GUID) for the record. If `nil`, an identifier may be assigned by the server or storage layer.
-    /// - eventType: The logical event type or schema name (e.g., "order-placed", "com.acme.orders.placed") used to populate `SchemaInfo.name`.
-    /// - payload: The event payload wrapped in `EventRecord.Payload`. Determines both the raw bytes and the schema format (`.json` for JSON models, `.bytes` for raw data).
-    /// - customMetadata: Optional raw metadata bytes. When provided, the initializer attempts to parse these bytes as a top-level JSON dictionary and stores the resulting key/value pairs into `properties`.
-    ///
-    /// Throws:
-    /// - An error if JSON encoding of a `.json` payload fails.
-    /// - An error if `customMetadata` is provided but cannot be parsed as a top-level JSON dictionary.
-    ///
-    /// Behavior:
-    /// - Builds `SchemaInfo` with `format` inferred from `payload.format` and `name` set to `eventType`.
-    /// - If `customMetadata` is non-nil, it is decoded using `JSONSerialization` with `.topLevelDictionaryAssumed` and merged into the record’s `properties`.
-    /// - Keys in `customMetadata` that begin with "$" are treated as system-reserved (e.g., "$trace-id", "$span-id", "$timestamp").
-    /// - User-defined metadata keys MUST NOT start with "$".
-    ///
-    /// Usage notes:
-    /// - Use `.json` payloads for Codable models to ensure consistent encoding and content typing.
-    /// - Provide raw `.data` payloads when you already have serialized bytes (e.g., Protobuf, Avro, or custom binary).
-    /// - Ensure that `eventType` is a stable, descriptive schema name to support long-term evolution and interoperability.
-    ///
-    /// Example:
-    /// - JSON model:
-    ///   let payload = EventRecord.Payload.json(MyEventModel(...))
-    ///   let record = try EventRecord(eventType: "order-placed", payload: payload)
-    ///
-    /// - Raw bytes with metadata:
-    ///   let meta = try JSONSerialization.data(withJSONObject: ["tenant": "acme", "$timestamp": "2026-02-11T10:00:00Z"])
-    ///   let payload = EventRecord.Payload.data(binaryBytes, .json) // or appropriate content type
-    ///   let record = try EventRecord(eventType: "order-placed", payload: payload, customMetadata: meta)
+    /// - Parameters:
+    ///   - id: Optional unique identifier; defaults to `nil` so the server can assign one.
+    ///   - eventType: Logical schema name set as `schema.name` (e.g., `"order-placed"`).
+    ///   - payload: Typed payload; its format is inferred and used to populate `schema.format`.
+    ///   - customMetadata: Optional JSON bytes parsed into `properties`; keys starting with `$` are system-reserved.
+    /// - Throws: `KurrentError` if JSON encoding or metadata parsing fails.
     public init(id: UUID? = nil, eventType: String, payload: Payload, customMetadata: Data? = nil) throws {
         let schema = Schema(format: payload.format, name: eventType)
         let properties = try customMetadata.flatMap {
@@ -119,27 +62,38 @@ extension EventRecord {
 }
 
 extension EventRecord: Buildable {
-    /// OpenTelemetry trace ID
+    /// Returns a copy of the record with the OpenTelemetry trace ID set.
+    ///
+    /// - Parameter value: W3C Trace Context trace ID string.
     public func traceId(_ value: String) -> Self {
         withCopy {
             $0.properties["$trace-id"] = value
         }
     }
 
-    /// OpenTelemetry span ID
+    /// Returns a copy of the record with the OpenTelemetry span ID set.
+    ///
+    /// - Parameter value: W3C Trace Context span ID string.
     public func spanId(_ value: String) -> Self {
         withCopy {
             $0.properties["$span-id"] = value
         }
     }
 
-    /// ISO 8601 timestamp
+    /// Returns a copy of the record with the ISO 8601 timestamp set.
+    ///
+    /// - Parameter value: ISO 8601 timestamp string (e.g., `"2026-02-11T10:00:00Z"`).
     public func timestamp(_ value: String) -> Self {
         withCopy {
             $0.properties["$timestamp"] = value
         }
     }
 
+    /// Returns a copy of the record with an arbitrary property value set.
+    ///
+    /// - Parameters:
+    ///   - value: The property value; must be `Codable` and `Sendable`.
+    ///   - key: The property key; must not start with `$` for user-defined properties.
     public func setValue(_ value: Codable & Sendable, forKey key: String) -> Self {
         withCopy {
             $0.properties[key] = value
@@ -148,55 +102,15 @@ extension EventRecord: Buildable {
 }
 
 extension EventRecord {
-    /// A type-erased container for event payloads that captures both raw bytes and structured JSON models,
-    /// along with their corresponding content types.
-    ///
-    /// Use `Payload` to standardize how event data is represented before encoding and transport.
-    /// It ensures that consumers can determine the correct `ContentType` and obtain a `Data` representation
-    /// regardless of whether the payload began as raw bytes or a Codable model.
-    ///
-    /// Cases:
-    /// - `data(Data, ContentType)`: Wraps already-encoded bytes with an explicit `ContentType`.
-    ///   Use this when you have pre-serialized data (e.g., Protobuf, Avro, custom binary, or JSON you encoded yourself).
-    /// - `json(Codable & Sendable)`: Wraps a Codable model that will be JSON-encoded on demand using `JSONEncoder`.
-    ///   The associated `contentType` is `.json`.
-    ///
-    /// Properties:
-    /// - `contentType`: The MIME-like content type describing how to interpret the payload.
-    ///   - For `.data(_, contentType)`, returns the provided `contentType`.
-    ///   - For `.json`, returns `.json`.
-    /// - `data`: Lazily produces a `Data` representation of the payload.
-    ///   - For `.data(data, _)`, returns the stored bytes.
-    ///   - For `.json(model)`, encodes the model using `JSONEncoder`.
-    ///   - May throw if JSON encoding fails.
-    ///
-    /// Thread safety:
-    /// - `Payload` is `Sendable` when its associated values are `Sendable`, enabling safe use across tasks.
-    ///
-    /// Usage notes:
-    /// - Prefer `.json` when working with Swift models to avoid manual encoding and to ensure consistent content typing.
-    /// - Use `.data` for non-JSON formats or when you have already-encoded bytes and want to retain control of serialization.
-    /// - When using `.data` with JSON bytes, set `ContentType.json` to maintain semantic correctness.
-    ///
-    /// Example:
-    /// - JSON model:
-    ///   ```swift
-    ///   struct Order: Codable, Sendable { let id: String; let total: Double }
-    ///   let payload = Payload.json(Order(id: "123", total: 42.0))
-    ///   let bytes = try payload.data            // JSON-encoded Data
-    ///   let type  = payload.contentType         // .json
-    ///   ```
-    /// - Raw bytes:
-    ///   ```swift
-    ///   let protobufBytes: Data = ...
-    ///   let payload = Payload.data(protobufBytes, .protobuf)
-    ///   let bytes = try payload.data            // returns protobufBytes
-    ///   let type  = payload.contentType         // .protobuf
-    ///   ```
+    /// Typed container for an event record's raw bytes or Codable model payload.
     public enum Payload: Sendable {
+        /// Pre-encoded bytes with an explicit content type.
         case data(Data, ContentType)
+
+        /// A Codable model that will be JSON-encoded on demand.
         case json(Codable & Sendable)
 
+        /// Content type of the payload.
         public var contentType: ContentType {
             switch self {
             case let .data(_, contentType):
@@ -206,6 +120,7 @@ extension EventRecord {
             }
         }
 
+        /// Serialized bytes of the payload; throws if JSON encoding fails.
         public var data: Data {
             get throws {
                 switch self {
@@ -217,6 +132,7 @@ extension EventRecord {
             }
         }
 
+        /// Schema format inferred from the payload case.
         public var format: Schema.Format {
             switch self {
             case .data:
@@ -229,107 +145,43 @@ extension EventRecord {
 }
 
 extension EventRecord.Schema {
-    /// Represents the encoding format of an event record's payload.
-    ///
-    /// Use this to indicate how the raw bytes in the associated data should be
-    /// interpreted for serialization and deserialization. Choosing the correct
-    /// format enables downstream systems to parse, validate, and evolve event
-    /// schemas consistently.
-    ///
-    /// Cases:
-    /// - `unspecified`: No explicit format is provided. This should be avoided in
-    ///   production as it prevents reliable decoding and validation.
-    /// - `json`: The payload is encoded as JSON (typically UTF-8). Suitable for
-    ///   human-readable data and broad interoperability. Consider schema evolution
-    ///   strategies (e.g., optional fields) when using JSON.
-    /// - `protobuf`: The payload is encoded using Protocol Buffers (binary).
-    ///   Efficient and strongly-typed with explicit schemas; good for high-throughput
-    ///   systems. Requires schema management for compatibility.
-    /// - `avro`: The payload is encoded using Apache Avro (binary or JSON).
-    ///   Designed for schema evolution and dynamic typing. Common in data pipelines
-    ///   and log/event streaming ecosystems.
-    /// - `bytes`: The payload is an opaque sequence of bytes with no declared
-    ///   higher-level format. Useful for custom or legacy encodings; consumers must
-    ///   agree out-of-band on how to interpret the data.
-    ///
-    /// Notes:
-    /// - Prefer specifying a concrete format (`json`, `protobuf`, `avro`) over
-    ///   `unspecified` or `bytes` to enable validation and tooling support.
-    /// - When using a schema-aware format (`protobuf`, `avro`), pair this with a
-    ///   concrete schema identifier/version to support compatibility and evolution.
-    /// - The format should match the `SchemaInfo.name` and optional `SchemaInfo.id`
-    ///   to ensure consistent interpretation across producers and consumers.
+    /// Encoding format of an event record's payload bytes.
     public enum Format: Int, Sendable {
+        /// No explicit format declared; avoid in production.
         case unspecified = 0
+
+        /// UTF-8 JSON encoding.
         case json = 1
+
+        /// Protocol Buffers binary encoding.
         case protobuf = 2
+
+        /// Apache Avro encoding.
         case avro = 3
+
+        /// Opaque byte sequence with no declared higher-level format.
         case bytes = 4
     }
 }
 
 extension EventRecord {
-    /// Encapsulates schema metadata for an event record's payload.
-    ///
-    /// Use `SchemaInfo` to describe how the raw `data` of an event should be
-    /// interpreted and validated. It pairs a concrete encoding format with a
-    /// human-meaningful schema name and an optional version/identifier, enabling
-    /// producers and consumers to evolve and validate payloads consistently.
-    ///
-    /// Topics:
-    /// - Format (`format`): Declares the encoding of the payload (e.g., JSON,
-    ///   Protobuf, Avro, or opaque bytes). This informs parsers how to decode the
-    ///   raw bytes.
-    /// - Name (`name`): Identifies the logical schema (replacing legacy “event
-    ///   type”). Common naming strategies include kebab-case (e.g., "order-placed"),
-    ///   URNs (e.g., "urn:kurrentdb:events:order-placed:v1"), dotted namespaces
-    ///   (e.g., "Orders.OrderPlaced.V2"), or reverse domains
-    ///   (e.g., "com.acme.orders.placed").
-    /// - Identifier (`id`): Optionally pins to a specific schema version or registry
-    ///   identifier, which is useful when enforcing validation and compatibility
-    ///   guarantees.
-    ///
-    /// Recommended usage:
-    /// - Prefer specifying a concrete `format` (e.g., `.json`, `.protobuf`, `.avro`)
-    ///   over unspecified or raw bytes to enable tooling and validation.
-    /// - Choose a stable `name` that conveys the semantic contract of the payload.
-    /// - Provide an `id` when integrating with a schema registry or when strict
-    ///   versioning and compatibility checks are required.
-    ///
-    /// Example:
-    /// - A JSON payload for an “order placed” event might use:
-    ///   - format: `.json`
-    ///   - name: "order-placed" or "com.acme.orders.placed"
-    ///   - id: "v1" or a registry GUID/URN
-    ///
-    /// Thread safety:
-    /// - `SchemaInfo` is an immutable value type; it is safe to share across
-    ///   threads and tasks.
-    ///
-    /// - Parameters:
-    ///   - format: The encoding format used for the payload data.
-    ///   - name: The logical schema name describing the payload contract.
-    ///   - id: An optional identifier for a specific schema version or registry entry.
+    /// Schema metadata describing the encoding format and logical name of an event record's payload.
     public struct Schema: Sendable {
-        /// The format of the data payload.
-        /// Determines how the bytes in AppendRecord.data should be interpreted.
+        /// Encoding format of the payload bytes.
         public let format: Format
 
-        /// The schema name (replaces the legacy "event type" concept).
-        /// Identifies what kind of data this record contains.
-        ///
-        /// Common naming formats:
-        ///   - Kebab-case: "order-placed", "customer-registered"
-        ///   - URN format: "urn:kurrentdb:events:order-placed:v1"
-        ///   - Dotted namespace: "Teams.Player.V1", "Orders.OrderPlaced.V2"
-        ///   - Reverse domain: "com.acme.orders.placed"
+        /// Logical schema name identifying the payload contract (replaces the legacy “event type”).
         public let name: String
 
-        /// The identifier of the specific version of the schema that the record payload
-        /// conforms to. This should match a registered schema version in the system.
-        /// Not necessary when not enforcing schema validation.
+        /// Optional schema version or registry identifier; omit when schema validation is not enforced.
         public let id: String?
 
+        /// Creates schema metadata with a format, name, and optional version identifier.
+        ///
+        /// - Parameters:
+        ///   - format: Encoding format of the payload.
+        ///   - name: Logical schema name (e.g., `”order-placed”`, `”com.acme.orders.placed”`).
+        ///   - id: Optional schema version or registry identifier.
         public init(format: Format, name: String, id: String? = nil) {
             self.format = format
             self.name = name

--- a/Sources/KurrentDB/Core/Event/EventStoreEvent.swift
+++ b/Sources/KurrentDB/Core/Event/EventStoreEvent.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
+/// Base protocol for all event types stored in KurrentDB.
 protocol EventStoreEvent: Sendable {
+    /// Unique identifier for this event.
     var id: UUID { get }
+
+    /// Logical type name describing the event's schema.
     var eventType: String { get }
 }

--- a/Sources/KurrentDB/Core/Event/ReadEvent.swift
+++ b/Sources/KurrentDB/Core/Event/ReadEvent.swift
@@ -8,11 +8,18 @@
 import Foundation
 import GRPCEncapsulates
 
+/// A single event returned from a stream read operation, pairing the recorded event with its link and position.
 public struct ReadEvent: Sendable {
+    /// The primary recorded event.
     public internal(set) var record: RecordedEvent
+
+    /// The resolved link event when reading from a projection or linked stream; `nil` otherwise.
     public internal(set) var link: RecordedEvent?
+
+    /// Global commit position of this event; `nil` when no position was provided by the server.
     public internal(set) var commitPosition: StreamPosition?
 
+    /// `true` when the server returned no commit position for this event.
     public var noPosition: Bool {
         commitPosition == nil
     }

--- a/Sources/KurrentDB/Core/Event/RecordedEvent.swift
+++ b/Sources/KurrentDB/Core/Event/RecordedEvent.swift
@@ -8,14 +8,27 @@
 import Foundation
 import GRPCEncapsulates
 
+/// An event read back from a KurrentDB stream, including its position and payload.
 public struct RecordedEvent: EventStoreEvent, Sendable {
+    /// Unique identifier assigned to this event.
     public private(set) var id: UUID
+
+    /// Logical schema name identifying the event's payload type.
     public private(set) var eventType: String
+
+    /// Content type of the payload bytes.
     public private(set) var contentType: ContentType
+
+    /// Identifier of the stream this event belongs to.
     public private(set) var streamIdentifier: StreamIdentifier
+
+    /// Stream-local revision number of this event.
     public private(set) var revision: UInt64
+
+    /// Commit and prepare position of this event in the global log.
     public private(set) var position: StreamPosition
 
+    /// gRPC metadata headers derived from `eventType` and `contentType`.
     public var metadata: [String: String] {
         [
             "type": eventType,
@@ -23,9 +36,17 @@ public struct RecordedEvent: EventStoreEvent, Sendable {
         ]
     }
 
+    /// Optional opaque metadata bytes stored alongside the event payload.
     public private(set) var customMetadata: Data
+
+    /// Raw payload bytes of the event.
     public private(set) var data: Data
 
+    /// Decodes the event payload into a `Decodable` type.
+    ///
+    /// - Parameter decodeType: The target type to decode the payload into.
+    /// - Returns: A decoded instance of `T`, or `nil` when the content type is not JSON.
+    /// - Throws: `DecodingError` if JSON decoding fails.
     public func decode<T: Decodable>(to decodeType: T.Type) throws -> T? {
         switch contentType {
         case .json:

--- a/Sources/KurrentDB/Core/Event/StreamEvent.swift
+++ b/Sources/KurrentDB/Core/Event/StreamEvent.swift
@@ -6,46 +6,40 @@
 //
 import Foundation
 
-/// A value that groups one or more events to be appended to a specific stream,
-/// along with the expected stream revision for optimistic concurrency control.
+/// Batch of event records destined for a single stream, with an expected revision for optimistic concurrency.
 ///
-/// Use `StreamEvent` when you want to write a batch of events atomically to a
-/// particular stream. The `expectedRevision` indicates what revision the stream
-/// must currently be at for the append to succeed. If the actual revision does
-/// not match, the write should fail to prevent lost updates.
-///
-/// Topics:
-/// - Stream identity:
-///   - `streamIdentifier`: Identifies the target stream for the events.
-/// - Event payloads:
-///   - `events`: The ordered collection of event data to append.
-/// - Concurrency control:
-///   - `expectedRevision`: The stream revision the writer expects before appending,
-///     typically used for optimistic concurrency checks. A default of `.any` can be
-///     used when no precondition is required.
-///
-/// Thread safety:
-/// - `StreamEvent` is an immutable, `Sendable` value type and can be safely
-///   shared across threads and tasks.
-///
-/// Initialization:
-/// - `init(streamIdentifier:events:expectedRevision:)`
-///   - Parameters:
-///     - streamIdentifier: The unique identifier of the target stream.
-///     - events: The events to append, in the order they should be persisted.
-///     - expectedRevision: The required current revision of the stream for the
-///       append to succeed. Defaults to `.any`.
+/// ```swift
+/// let event = try EventRecord(eventType: "order-placed", payload: .json(order))
+/// let streamEvent = StreamEvent(stream: "orders", records: event)
+/// ```
 public struct StreamEvent: Sendable {
+    /// Target stream identifier.
     public let streamIdentifier: StreamIdentifier
+
+    /// Ordered records to append.
     public let records: [EventRecord]
+
+    /// Required current stream revision; the append fails if the stream is at a different revision.
     public let expectedRevision: StreamRevision
 
+    /// Creates a `StreamEvent` with a `StreamIdentifier` and an array of records.
+    ///
+    /// - Parameters:
+    ///   - streamIdentifier: Target stream identifier.
+    ///   - records: Ordered records to append.
+    ///   - expectedRevision: Required current stream revision; defaults to `.any`.
     public init(stream streamIdentifier: StreamIdentifier, records: [EventRecord], expectedRevision: StreamRevision = .any) {
         self.streamIdentifier = streamIdentifier
         self.records = records
         self.expectedRevision = expectedRevision
     }
 
+    /// Creates a `StreamEvent` with a stream name string and an array of records.
+    ///
+    /// - Parameters:
+    ///   - streamName: Target stream name.
+    ///   - records: Ordered records to append.
+    ///   - expectedRevision: Required current stream revision; defaults to `.any`.
     public init(stream streamName: String, records: [EventRecord], expectedRevision: StreamRevision = .any) {
         streamIdentifier = .init(name: streamName)
         self.records = records
@@ -54,12 +48,24 @@ public struct StreamEvent: Sendable {
 }
 
 extension StreamEvent {
+    /// Creates a `StreamEvent` with a `StreamIdentifier` and variadic records.
+    ///
+    /// - Parameters:
+    ///   - streamIdentifier: Target stream identifier.
+    ///   - records: One or more records to append, in order.
+    ///   - expectedRevision: Required current stream revision; defaults to `.any`.
     public init(stream streamIdentifier: StreamIdentifier, records: EventRecord..., expectedRevision: StreamRevision = .any) {
         self.streamIdentifier = streamIdentifier
         self.records = records
         self.expectedRevision = expectedRevision
     }
 
+    /// Creates a `StreamEvent` with a stream name string and variadic records.
+    ///
+    /// - Parameters:
+    ///   - streamName: Target stream name.
+    ///   - records: One or more records to append, in order.
+    ///   - expectedRevision: Required current stream revision; defaults to `.any`.
     public init(stream streamName: String, records: EventRecord..., expectedRevision: StreamRevision = .any) {
         streamIdentifier = .init(name: streamName)
         self.records = records
@@ -68,6 +74,13 @@ extension StreamEvent {
 }
 
 extension StreamEvent {
+    /// Creates a `StreamEvent` from variadic `EventData` values using a `StreamIdentifier`.
+    ///
+    /// - Parameters:
+    ///   - streamIdentifier: Target stream identifier.
+    ///   - eventData: One or more legacy `EventData` values to convert and append.
+    ///   - expectedRevision: Required current stream revision; defaults to `.any`.
+    /// - Throws: `KurrentError` if any `EventData` cannot be converted to an `EventRecord`.
     public init(stream streamIdentifier: StreamIdentifier, eventData: EventData..., expectedRevision: StreamRevision = .any) throws {
         self.streamIdentifier = streamIdentifier
         records = try eventData.map {
@@ -76,6 +89,13 @@ extension StreamEvent {
         self.expectedRevision = expectedRevision
     }
 
+    /// Creates a `StreamEvent` from variadic `EventData` values using a stream name string.
+    ///
+    /// - Parameters:
+    ///   - streamName: Target stream name.
+    ///   - eventData: One or more legacy `EventData` values to convert and append.
+    ///   - expectedRevision: Required current stream revision; defaults to `.any`.
+    /// - Throws: `KurrentError` if any `EventData` cannot be converted to an `EventRecord`.
     public init(stream streamName: String, eventData: EventData..., expectedRevision: StreamRevision = .any) throws {
         streamIdentifier = .init(name: streamName)
         records = try eventData.map {

--- a/Sources/KurrentDB/Core/NodeSelector.swift
+++ b/Sources/KurrentDB/Core/NodeSelector.swift
@@ -9,6 +9,11 @@ import Foundation
 import GRPCCore
 import GRPCNIOTransportHTTP2
 
+/// Selects and caches the best available cluster node for client connections.
+///
+/// Wraps ``NodeDiscover`` to run gossip-based node discovery and caches the chosen
+/// ``Node`` for the duration specified by `ClientSettings.nodeCacheTTL`. Call ``select()``
+/// before every RPC; the cached node is returned until it expires or is invalidated.
 public actor NodeSelector: Sendable {
     let id: UUID?
     let settings: ClientSettings
@@ -22,13 +27,18 @@ public actor NodeSelector: Sendable {
         discover = .init(settings: settings, previousCandidates: [])
     }
 
-    /// The operation retry policy from the client settings.
-    /// Declared `nonisolated` because `settings` is an immutable `let` of a `Sendable` type,
-    /// so it is safe to read without actor isolation.
+    /// Operation retry policy sourced from the client settings.
     nonisolated var retryPolicy: OperationRetryPolicy {
         settings.operationRetryPolicy
     }
 
+    /// Returns the best available cluster node, using a cached result when still valid.
+    ///
+    /// Runs gossip-based discovery when the cache is empty or expired. Retries up to
+    /// `ClientSettings.maxDiscoveryAttempts` times with `discoveryInterval` between attempts.
+    ///
+    /// - Returns: A ``Node`` ready to accept gRPC connections.
+    /// - Throws: `KurrentError.serverError` if no reachable node is found within the attempt limit.
     public func select() async throws(KurrentError) -> Node {
         if let node = selectedNode, let expiry = selectedNodeExpiry, Date.now < expiry {
             return node
@@ -44,8 +54,7 @@ public actor NodeSelector: Sendable {
         return node
     }
 
-    /// Clears the cached node so the next call to `select()` triggers a fresh discovery.
-    /// Call this when a node-level failure is detected (connection error, not-leader, timeout).
+    /// Clears the cached node so the next ``select()`` call triggers fresh discovery.
     func invalidate() {
         logger.debug("[NodeSelector] Invalidating cached node, will re-discover on next select.")
         selectedNode = nil
@@ -82,6 +91,7 @@ public actor NodeSelector: Sendable {
     }
 }
 
+/// Iterates over cluster candidates via gossip to find the preferred reachable endpoint.
 public actor NodeDiscover: AsyncIteratorProtocol, Sendable {
     public typealias Element = Endpoint
 
@@ -94,6 +104,13 @@ public actor NodeDiscover: AsyncIteratorProtocol, Sendable {
         previousCandidates = []
     }
 
+    /// Returns the best endpoint discovered via gossip, or `nil` if no live member is found.
+    ///
+    /// Shuffles the candidate list, queries each candidate's gossip API, and returns the
+    /// HTTP endpoint of the first alive member. Subsequent calls return the cached endpoint.
+    ///
+    /// - Returns: The preferred ``Endpoint`` for gRPC connections, or `nil` if discovery fails.
+    /// - Throws: `KurrentError` if the gossip request to a candidate cannot be completed.
     public func next() async throws(KurrentError) -> Endpoint? {
         guard selectedEndpoint == nil else {
             return selectedEndpoint

--- a/Sources/KurrentDB/Core/PersistenSubscription/PersistenSubscription.EventResult.swift
+++ b/Sources/KurrentDB/Core/PersistenSubscription/PersistenSubscription.EventResult.swift
@@ -21,15 +21,16 @@ extension PersistentSubscription {
 }
 
 
+/// Provides stream-position metadata so that `EventResult` can be used as the
+/// generic parameter of ``PersistentSubscriptions/Subscription``.
 extension PersistentSubscription.EventResult: SubscriptionEventResult {
+    /// Stream revision of the underlying recorded event.
     public var revision: UInt64? {
-        get {
-            event.record.revision
-        }
+        event.record.revision
     }
+
+    /// Commit position of the event in the `$all` stream.
     public var position: StreamPosition? {
-        get{
-            event.commitPosition
-        }
+        event.commitPosition
     }
 }

--- a/Sources/KurrentDB/Core/PersistenSubscription/PersistenSubscription.EventResult.swift
+++ b/Sources/KurrentDB/Core/PersistenSubscription/PersistenSubscription.EventResult.swift
@@ -6,8 +6,11 @@
 //
 
 extension PersistentSubscription {
+    /// An event delivered by a persistent subscription together with its retry metadata.
     public struct EventResult: Sendable {
+        /// The event read from the stream.
         public let event: ReadEvent
+        /// Number of times this event has been retried after a previous nack or timeout.
         public let retryCount: Int32
 
         package init(event: ReadEvent, retryCount: Int32) {

--- a/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.ConnectionInfo.swift
+++ b/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.ConnectionInfo.swift
@@ -6,15 +6,25 @@
 //
 
 extension PersistentSubscription {
+    /// Statistics for a single consumer connection to a persistent subscription.
     public struct ConnectionInfo: Sendable {
+        /// Network address or identifier of the connected client.
         public let from: String
+        /// Username of the authenticated client.
         public let username: String
+        /// Average number of events delivered to this connection per second.
         public let averageItemsPerSecond: Int32
+        /// Total number of events delivered over the lifetime of this connection.
         public let totalItems: Int64
+        /// Number of events delivered since the last measurement snapshot.
         public let countSinceLastMeasurement: Int64
+        /// Detailed throughput samples captured during the observation window.
         public let obervedMeasurements: [Measurement]
+        /// Number of buffer slots currently available for new in-flight messages.
         public let availableSlots: Int32
+        /// Number of messages currently awaiting acknowledgement from this connection.
         public let inFlightMessages: Int32
+        /// Human-readable name assigned to this connection by the client.
         public let connectionName: String
     }
 }

--- a/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.Measurement.swift
+++ b/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.Measurement.swift
@@ -6,8 +6,11 @@
 //
 
 extension PersistentSubscription {
+    /// A single named throughput sample reported by the server.
     public struct Measurement: Sendable {
+        /// Name of the metric being measured.
         public let key: String
+        /// Numeric value of the measurement at the time of sampling.
         public let value: Int64
     }
 }

--- a/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.Settings.swift
+++ b/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.Settings.swift
@@ -6,38 +6,39 @@
 //
 
 extension PersistentSubscription {
+    /// Settings for creating a new persistent subscription.
     public struct CreateSettings: Sendable {
+        /// Whether linked events are resolved to their original event.
         public var resolveLink: Bool
 
-        /// Whether or not in depth latency statistics should be tracked on this
-        /// subscription.
+        /// Whether in-depth latency statistics are tracked for this subscription.
         public var extraStatistics: Bool
 
-        /// The amount of time (ms) after which a message should be considered to be
-        /// timeout and retried.
+        /// Time in milliseconds before an unacknowledged message is considered timed out and retried.
         public var messageTimeout: TimeSpan
 
-        /// The maximum number of retries (due to timeout) before a message get
-        /// considered to be parked.
+        /// Maximum number of delivery retries before a message is parked.
         public var maxRetryCount: Int32
 
+        /// Inclusive range of events that must be processed before a checkpoint is written.
         public var checkpointCount: ClosedRange<Int32>
 
+        /// Maximum number of subscribers allowed to connect concurrently; 0 means unlimited.
         public var maxSubscriberCount: Int32
 
-        /// The size of the buffer listening to live messages as they happen.
+        /// Size of the in-memory buffer for live events arriving in real time.
         public var liveBufferSize: Int32
 
-        /// The number of events read at a time when paging in history.
+        /// Number of events fetched per page when reading historical events.
         public var readBatchSize: Int32
 
-        /// The number of events to cache when paging through history.
+        /// Number of historical events held in the cache while paging through history.
         public var historyBufferSize: Int32
 
-        /// The amount of time (ms) to try checkpoint after.
+        /// Minimum time in milliseconds between checkpoint writes.
         public var checkpointAfter: TimeSpan
 
-        /// The strategy to use for distributing events to client consumers.
+        /// Strategy used to distribute events among connected consumers.
         public var consumerStrategy: SystemConsumerStrategy = .roundRobin
 
         public init(
@@ -67,35 +68,36 @@ extension PersistentSubscription {
         }
     }
 
+    /// Settings for updating an existing persistent subscription; all fields are optional.
     public struct UpdateSettings: Sendable {
+        /// Whether linked events are resolved to their original event.
         public var resolveLink: Bool?
 
-        /// Whether or not in depth latency statistics should be tracked on this
-        /// subscription.
+        /// Whether in-depth latency statistics are tracked for this subscription.
         public var extraStatistics: Bool?
 
-        /// The amount of time (ms) after which a message should be considered to be
-        /// timeout and retried.
+        /// Time in milliseconds before an unacknowledged message is considered timed out and retried.
         public var messageTimeout: TimeSpan?
 
-        /// The maximum number of retries (due to timeout) before a message get
-        /// considered to be parked.
+        /// Maximum number of delivery retries before a message is parked.
         public var maxRetryCount: Int32?
 
+        /// Inclusive range of events that must be processed before a checkpoint is written.
         public var checkpointCount: ClosedRange<Int32>?
 
+        /// Maximum number of subscribers allowed to connect concurrently; 0 means unlimited.
         public var maxSubscriberCount: Int32?
 
-        /// The size of the buffer listening to live messages as they happen.
+        /// Size of the in-memory buffer for live events arriving in real time.
         public var liveBufferSize: Int32?
 
-        /// The number of events read at a time when paging in history.
+        /// Number of events fetched per page when reading historical events.
         public var readBatchSize: Int32?
 
-        /// The number of events to cache when paging through history.
+        /// Number of historical events held in the cache while paging through history.
         public var historyBufferSize: Int32?
 
-        /// The amount of time (ms) to try checkpoint after.
+        /// Minimum time in milliseconds between checkpoint writes.
         public var checkpointAfter: TimeSpan?
 
         package init(){ }

--- a/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.StreamSelection.swift
+++ b/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.StreamSelection.swift
@@ -6,8 +6,11 @@
 //
 
 extension PersistentSubscription {
+    /// Identifies which stream a persistent subscription reads from.
     public enum StreamSelection {
+        /// Reads from the global `$all` stream, optionally starting at a position and applying a filter.
         case all(position: PositionCursor, filterOption: SubscriptionFilter? = nil)
+        /// Reads from a specific named stream starting at the given revision.
         case specified(identifier: StreamIdentifier, revision: RevisionCursor)
 
         public static func specified(identifier: StreamIdentifier) -> Self {

--- a/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.SubscriptionInfo.swift
+++ b/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.SubscriptionInfo.swift
@@ -8,35 +8,64 @@
 import GRPCEncapsulates
 
 extension PersistentSubscription {
+    /// Snapshot of the server-side state and configuration for a persistent subscription.
     public struct SubscriptionInfo: GRPCBridge {
         package typealias UnderlyingMessage = EventStore_Client_PersistentSubscriptions_SubscriptionInfo
+        /// Stream name or `$all` that this subscription reads from.
         public let eventSource: String
+        /// Consumer group name for this subscription.
         public let groupName: String
+        /// Human-readable status reported by the server (e.g., "Live", "CatchUp").
         public let status: String
+        /// Active consumer connections to this subscription.
         public let connections: [ConnectionInfo]
+        /// Average number of events processed per second across all connections.
         public let averagePerSecond: Int32
+        /// Total number of events delivered since the subscription was created.
         public let totalItems: Int64
+        /// Number of events delivered since the last measurement snapshot.
         public let countSinceLastMeasurement: Int64
+        /// Position of the last successfully checkpointed event.
         public let lastCheckpointedEventPosition: String
+        /// Position of the most recent event known to this subscription.
         public let lastKnownEventPosition: String
+        /// Whether linked events are resolved to their original event.
         public let resolveLinkTos: Bool
+        /// Stream position or revision from which this subscription started reading.
         public let startFrom: String
+        /// Milliseconds before an unacknowledged message times out and is retried.
         public let messageTimeoutMilliseconds: Int32
+        /// Whether in-depth latency statistics are enabled for this subscription.
         public let extraStatistics: Bool
+        /// Maximum number of delivery retries before a message is parked.
         public let maxRetryCount: Int32
+        /// Capacity of the in-memory buffer for live events.
         public let liveBufferSize: Int32
+        /// Total capacity of the internal event buffer.
         public let bufferSize: Int32
+        /// Number of events fetched per page when reading historical events.
         public let readBatchSize: Int32
+        /// Minimum time in milliseconds between checkpoint writes.
         public let checkPointAfterMilliseconds: Int32
+        /// Minimum number of events required before a checkpoint is written.
         public let minCheckPointCount: Int32
+        /// Maximum number of events allowed between checkpoint writes.
         public let maxCheckPointCount: Int32
+        /// Current number of events in the read buffer.
         public let readBufferCount: Int32
+        /// Current number of events in the live buffer.
         public let liveBufferCount: Int64
+        /// Current number of events in the retry buffer.
         public let retryBufferCount: Int32
+        /// Total number of messages currently in flight across all connections.
         public let totalInFlightMessages: Int32
+        /// Total number of messages awaiting acknowledgement.
         public let outstandingMessageCount: Int32
+        /// Raw string identifying the consumer dispatch strategy.
         public let namedConsumerStrategy: String
+        /// Maximum number of concurrent subscribers; 0 means unlimited.
         public let maxSubscriberCount: Int32
+        /// Number of messages currently held in the parked message queue.
         public let parkedMessageCount: Int64
 
         package init(

--- a/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.SystemConsumerStrategy.swift
+++ b/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.SystemConsumerStrategy.swift
@@ -6,33 +6,23 @@
 //
 
 extension PersistentSubscription {
+    /// Strategy used by the server to dispatch events to competing consumers.
     public enum SystemConsumerStrategy: RawRepresentable, Sendable {
         public typealias RawValue = String
 
-        /// Distributes events to a single client until the bufferSize is reached.
-        /// After which the next client is selected in a round robin style,
-        /// and the process is repeated.
+        /// Fills one consumer's buffer before moving to the next in round-robin order.
         case dispatchToSingle
 
-        /// Distributes events to all clients evenly. If the client buffer-size
-        /// is reached the client is ignored until events are
-        /// acknowledged/not acknowledged.
+        /// Distributes events evenly across all connected consumers.
         case roundRobin
 
-        /// For use with an indexing projection such as the system $by_category
-        /// projection. Event Store inspects event for its source stream id,
-        /// hashing the id to one of 1024 buckets assigned to individual clients.
-        /// When a client disconnects it's buckets are assigned to other clients.
-        /// When a client connects, it is assigned some of the existing buckets.
-        /// This naively attempts to maintain a balanced workload.
-        /// The main aim of this strategy is to decrease the likelihood of
-        /// concurrency and ordering issues while maintaining load balancing.
-        /// This is not a guarantee, and you should handle the usual ordering
-        /// and concurrency issues.
+        /// Routes events to consumers by hashing the source stream identifier, reducing ordering conflicts.
         case pinned
 
+        /// Routes events to consumers by hashing the correlation identifier.
         case pinnedByCorrelation
 
+        /// A custom strategy identified by the given raw string value.
         case custom(String)
 
         public var rawValue: String {

--- a/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.swift
+++ b/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.swift
@@ -5,4 +5,5 @@
 //  Created by 卓俊諺 on 2025/1/12.
 //
 
+/// Namespace for persistent subscription types, settings, and metadata.
 public struct PersistentSubscription {}

--- a/Sources/KurrentDB/Core/Projection/Projection.Detail.swift
+++ b/Sources/KurrentDB/Core/Projection/Projection.Detail.swift
@@ -6,26 +6,45 @@
 //
 
 extension Projection {
-    /// Detailed statistics for a single projection.
+    /// Runtime statistics and configuration details for a single projection.
     public struct Detail: Sendable {
+        /// Total CPU time consumed by the projection's core processing, in milliseconds.
         public let coreProcessingTime: Int64
+        /// Current version of the projection definition.
         public let version: Int64
+        /// Epoch counter, incremented on each restart.
         public let epoch: Int64
+        /// Effective name used by the server for this projection.
         public let effectiveName: String
+        /// Number of write operations currently in progress.
         public let writesInProgress: Int32
+        /// Number of read operations currently in progress.
         public let readsInProgress: Int32
+        /// Number of partition states currently cached in memory.
         public let partitionsCached: Int32
+        /// Current operational status of the projection.
         public let status: Projection.Status
+        /// Human-readable reason for the current state, if applicable.
         public let stateReason: String
+        /// Name of the projection.
         public let name: String
+        /// Mode under which the projection operates.
         public let mode: Projection.Mode
+        /// Current position of the projection in the event log.
         public let position: String
+        /// Percentage of the event log processed, from 0 to 100.
         public let progress: Float
+        /// Position recorded at the most recent checkpoint.
         public let lastCheckpoint: String
+        /// Number of events processed since the projection last restarted.
         public let eventsProcessedAfterRestart: Int64
+        /// Current checkpoint write status.
         public let checkpointStatus: String
+        /// Number of events buffered and awaiting processing.
         public let bufferedEvents: Int64
+        /// Number of events pending write before the next checkpoint.
         public let writePendingEventsBeforeCheckpoint: Int32
+        /// Number of events pending write after the most recent checkpoint.
         public let writePendingEventsAfterCheckpoint: Int32
 
         init(coreProcessingTime: Int64, version: Int64, epoch: Int64, effectiveName: String, writesInProgress: Int32, readsInProgress: Int32, partitionsCached: Int32, status: String, stateReason: String, name: String, mode: String, position: String, progress: Float, lastCheckpoint: String, eventsProcessedAfterRestart: Int64, checkpointStatus: String, bufferedEvents: Int64, writePendingEventsBeforeCheckpoint: Int32, writePendingEventsAfterCheckpoint: Int32) throws(KurrentError) {

--- a/Sources/KurrentDB/Core/Projection/Projection.Mode.swift
+++ b/Sources/KurrentDB/Core/Projection/Projection.Mode.swift
@@ -11,7 +11,7 @@ extension Projection {
         /// No specific mode constraint; matches any projection mode.
         case any = "Any"
 
-        /// Runs in-process and is discarded when the connection closes.
+        /// Runs server-side without a checkpoint; discarded when the server restarts.
         case transient = "Transient"
 
         /// Runs indefinitely, processing events as they arrive.

--- a/Sources/KurrentDB/Core/Projection/Projection.Mode.swift
+++ b/Sources/KurrentDB/Core/Projection/Projection.Mode.swift
@@ -6,21 +6,18 @@
 //
 
 extension Projection {
-    /// Defines the operational modes of a projection.
-    ///
-    /// `Mode` specifies how a projection operates, such as continuously or as a one-time task.
-    /// It is marked as `Sendable`, ensuring it can be safely used across concurrency contexts.
+    /// Operational mode of a projection.
     public enum Mode: String, Sendable {
-        /// Represents a projection with no specific mode constraint.
+        /// No specific mode constraint; matches any projection mode.
         case any = "Any"
 
-        /// Represents a transient projection (currently unavailable).
+        /// Runs in-process and is discarded when the connection closes.
         case transient = "Transient"
 
-        /// Represents a projection that runs continuously, processing events as they occur.
+        /// Runs indefinitely, processing events as they arrive.
         case continuous = "Continuous"
 
-        /// Represents a projection that runs once and then completes.
+        /// Runs once over existing events and then stops.
         case oneTime = "OneTime"
     }
 }

--- a/Sources/KurrentDB/Core/Projection/Projection.Status.swift
+++ b/Sources/KurrentDB/Core/Projection/Projection.Status.swift
@@ -6,10 +6,14 @@
 //
 
 extension Projection {
+    /// Composite status value reported by the server for a projection.
     public struct Status: Sendable {
+        /// Raw status string as returned by the server.
         public typealias RawValue = String
+        /// Underlying status string, which may contain multiple slash-separated state names.
         public let rawValue: String
 
+        /// Parsed list of individual status names extracted from the raw value.
         public var names: [Name] {
             rawValue.replacing(" results", with: "")
                 .split(separator: "/")
@@ -25,22 +29,39 @@ extension Projection {
 }
 
 extension Projection.Status {
+    /// Individual named state component of a projection's status.
     public enum Name: String, Sendable {
+        /// Projection is actively processing events.
         case running = "Running"
+        /// Projection has been stopped cleanly.
         case stopped = "Stopped"
+        /// Projection encountered an unrecoverable error.
         case faulted = "Faulted"
+        /// Projection has been created but not yet started.
         case initial = "Initial"
+        /// Projection is writing results.
         case writing = "Writing"
+        /// Projection finished processing all events (one-time mode).
         case completed = "Completed"
+        /// Projection is suspended and not currently processing.
         case suspended = "Suspended"
+        /// Projection is requesting its persisted state to be loaded.
         case loadStateRequested = "LoadStateRequested"
+        /// Projection's persisted state has been loaded successfully.
         case stateLoaded = "StateLoaded"
+        /// Projection has subscribed to the event stream.
         case subscribed = "Subscribed"
+        /// Projection encountered an error while stopping.
         case faultedStopping = "FaultedStopping"
+        /// Projection is in the process of stopping.
         case stopping = "Stopping"
+        /// Projection is completing the current processing phase.
         case completingPhase = "CompletingPhase"
+        /// Current processing phase has completed.
         case phaseCompleted = "PhaseCompleted"
+        /// Projection was aborted without writing a checkpoint.
         case aborted = "Aborted"
+        /// Projection is faulted but has been re-enabled.
         case faultedEnabled = "Faulted (Enabled)"
     }
 

--- a/Sources/KurrentDB/Core/Projection/Projection.Status.swift
+++ b/Sources/KurrentDB/Core/Projection/Projection.Status.swift
@@ -22,6 +22,7 @@ extension Projection {
                 }
         }
 
+        /// Creates a status from the raw server string.
         public init(rawValue: String) {
             self.rawValue = rawValue
         }

--- a/Sources/KurrentDB/Core/Projection/Projection.swift
+++ b/Sources/KurrentDB/Core/Projection/Projection.swift
@@ -5,4 +5,5 @@
 //  Created by Grady Zhuo on 2025/3/13.
 //
 
+/// Namespace for projection-related types and values.
 public struct Projection {}

--- a/Sources/KurrentDB/Core/RetryPolicy.swift
+++ b/Sources/KurrentDB/Core/RetryPolicy.swift
@@ -5,23 +5,18 @@
 
 import Foundation
 
-/// Configures retry behavior for operations that encounter node-level failures.
+/// Retry behaviour applied to operations that fail due to node-level errors.
 ///
-/// When an operation fails with a ``KurrentError`` whose `isNodeFailure` is `true`
-/// (e.g. connection errors, not-leader, deadline exceeded), the client will
-/// invalidate the cached node, re-discover a new one, and retry the operation
-/// up to `maxAttempts` total times with exponential backoff between retries.
-///
-/// ## Example
+/// When an operation throws a `KurrentError` whose `isNodeFailure` is `true`, the client
+/// invalidates the cached node, discovers a new one, and retries up to `maxAttempts` times
+/// with exponential backoff and optional jitter between attempts.
 ///
 /// ```swift
-/// // Enable exponential backoff with sensible defaults (3 attempts, 100ms → 10s)
 /// let settings = ClientSettings.localhost()
-///     .operationOperationRetryPolicy(.default)
+///     .operationRetryPolicy(.default)
 ///
-/// // Fully custom policy
-/// let settings = ClientSettings.localhost()
-///     .operationOperationRetryPolicy(OperationRetryPolicy(
+/// let custom = ClientSettings.localhost()
+///     .operationRetryPolicy(OperationRetryPolicy(
 ///         maxAttempts: 5,
 ///         initialDelay: .milliseconds(200),
 ///         maxDelay: .seconds(30),
@@ -31,32 +26,37 @@ import Foundation
 /// ```
 public struct OperationRetryPolicy: Sendable {
 
-    /// Total number of attempts, including the first try.
-    /// `maxAttempts: 1` means no retry (legacy behavior).
-    /// `maxAttempts: 3` means 1 initial attempt + 2 retries.
+    /// Total number of attempts including the first try; `1` means no retries.
     public var maxAttempts: Int
 
-    /// Delay before the first retry. Set to `.zero` for no delay.
+    /// Delay before the first retry; `.zero` means retry immediately.
     public var initialDelay: Duration
 
-    /// Maximum delay between retries. Acts as a cap on exponential growth.
+    /// Upper bound on the delay between retries, capping exponential growth.
     public var maxDelay: Duration
 
-    /// Backoff multiplier applied to the delay after each retry.
-    /// `2.0` doubles the delay each time.
+    /// Multiplier applied to the current delay after each retry; `2.0` doubles the delay.
     public var multiplier: Double
 
-    /// Jitter strategy to avoid thundering-herd when many clients retry simultaneously.
+    /// Jitter strategy used to spread retry timing across concurrent clients.
     public var jitter: JitterStrategy
 
+    /// Strategy for randomising the retry delay to reduce thundering-herd effects.
     public enum JitterStrategy: Sendable {
-        /// No jitter. Delay is deterministic.
+        /// No jitter; the computed delay is used as-is.
         case none
-        /// Full jitter: actual delay = `delay * random(0.0...1.0)`.
+        /// Full jitter: actual delay is `delay * random(0.0...1.0)`.
         case full
     }
 
-    /// Initialises a retry policy.
+    /// Creates a retry policy with explicit values for all parameters.
+    ///
+    /// - Parameters:
+    ///   - maxAttempts: Total number of attempts, including the initial try.
+    ///   - initialDelay: Delay before the first retry.
+    ///   - maxDelay: Maximum delay between retries.
+    ///   - multiplier: Exponential backoff multiplier applied after each retry.
+    ///   - jitter: Jitter strategy to spread retries across concurrent clients.
     public init(
         maxAttempts: Int,
         initialDelay: Duration,
@@ -71,8 +71,7 @@ public struct OperationRetryPolicy: Sendable {
         self.jitter = jitter
     }
 
-    /// A policy with sensible defaults: 3 total attempts, 100 ms initial delay,
-    /// 2× backoff, 10 s cap, and full jitter.
+    /// Sensible default policy: 3 total attempts, 100 ms initial delay, 2× backoff, 10 s cap, full jitter.
     public static let `default` = OperationRetryPolicy(
         maxAttempts: 3,
         initialDelay: .milliseconds(100),

--- a/Sources/KurrentDB/Core/Stream/StreamIdentifier.swift
+++ b/Sources/KurrentDB/Core/Stream/StreamIdentifier.swift
@@ -9,12 +9,28 @@ import Foundation
 import GRPCEncapsulates
 import RegexBuilder
 
+/// Identifies a KurrentDB stream by name.
+///
+/// Conforms to `ExpressibleByStringLiteral`, so a stream identifier can be created directly
+/// from a string literal wherever the type is known.
+///
+/// ```swift
+/// let stream: StreamIdentifier = "orders-123"
+/// let stream = StreamIdentifier(name: "orders-123")
+/// ```
 public struct StreamIdentifier: Sendable {
     package typealias UnderlyingMessage = EventStore_Client_StreamIdentifier
 
+    /// Stream name.
     public let name: String
+    /// String encoding used when serialising the name to bytes.
     public var encoding: String.Encoding
 
+    /// Creates a stream identifier with the given name and optional encoding.
+    ///
+    /// - Parameters:
+    ///   - name: The stream name.
+    ///   - encoding: The string encoding used when serialising the name. Defaults to `.utf8`.
     public init(name: String, encoding: String.Encoding = .utf8) {
         self.name = name
         self.encoding = encoding
@@ -22,6 +38,9 @@ public struct StreamIdentifier: Sendable {
 }
 
 extension StreamIdentifier {
+    /// Category prefix extracted from a hyphen-delimited stream name, or `nil` if none.
+    ///
+    /// For a stream named `"orders-123"` this returns `"orders"`.
     public var category: String? {
         let _category = Reference<String>()
         return name.prefixMatch(of: Regex {
@@ -62,6 +81,7 @@ extension StreamIdentifier {
 }
 
 extension StreamIdentifier {
+    /// Identifier for the global `$all` stream.
     public static var all: Self {
         .init(name: "$all")
     }

--- a/Sources/KurrentDB/Core/Stream/StreamMetadata.swift
+++ b/Sources/KurrentDB/Core/Stream/StreamMetadata.swift
@@ -8,6 +8,11 @@
 import Foundation
 import GRPCEncapsulates
 
+/// Configuration metadata attached to a KurrentDB stream.
+///
+/// Controls retention, truncation, caching, and access control for a stream.
+/// Use the builder methods to configure individual fields and pass the result to
+/// `setStreamMetadata` on the client.
 public struct StreamMetadata: Buildable, Codable {
     enum CodingKeys: String, CodingKey {
         case maxCount = "$maxCount"
@@ -44,6 +49,7 @@ public struct StreamMetadata: Buildable, Codable {
     // user-provided metadata.
     var customProperties: [String: String]?
 
+    /// Creates a `StreamMetadata` value with all fields unset.
     public init() {
         maxCount = nil
         maxAge = nil
@@ -53,36 +59,60 @@ public struct StreamMetadata: Buildable, Codable {
         customProperties = nil
     }
 
+    /// Sets the maximum number of events retained in the stream.
+    ///
+    /// - Parameter maxCount: Maximum event count before older events become eligible for scavenging.
+    /// - Returns: An updated copy of the metadata.
     public func maxCount(_ maxCount: UInt64) -> Self {
         withCopy { copied in
             copied.maxCount = maxCount
         }
     }
 
+    /// Sets the maximum age of events retained in the stream.
+    ///
+    /// - Parameter maxAge: Maximum age before events become eligible for scavenging.
+    /// - Returns: An updated copy of the metadata.
     public func maxAge(_ maxAge: Duration) -> Self {
         withCopy { copied in
             copied.maxAge = maxAge
         }
     }
 
+    /// Sets the event revision before which all events may be scavenged.
+    ///
+    /// - Parameter truncateBefore: Event revision acting as the soft-delete boundary.
+    /// - Returns: An updated copy of the metadata.
     public func truncateBefore(_ truncateBefore: UInt64) -> Self {
         withCopy { copied in
             copied.truncateBefore = truncateBefore
         }
     }
 
+    /// Sets the cache-control duration for the stream head.
+    ///
+    /// - Parameter cacheControl: Duration for which intermediaries may cache the stream head.
+    /// - Returns: An updated copy of the metadata.
     public func cacheControl(_ cacheControl: Duration) -> Self {
         withCopy { copied in
             copied.cacheControl = cacheControl
         }
     }
 
+    /// Sets the access control list for the stream.
+    ///
+    /// - Parameter acl: The `Acl` value to apply.
+    /// - Returns: An updated copy of the metadata.
     public func acl(_ acl: Acl) -> Self {
         withCopy { copied in
             copied.acl = acl
         }
     }
 
+    /// Sets user-defined key-value metadata on the stream.
+    ///
+    /// - Parameter customProperties: Dictionary of string keys to JSON-serialisable string values.
+    /// - Returns: An updated copy of the metadata.
     public func customProperties(_ customProperties: [String: String]) -> Self {
         withCopy { copied in
             copied.customProperties = customProperties
@@ -98,9 +128,11 @@ public struct StreamMetadata: Buildable, Codable {
 }
 
 extension StreamMetadata {
+    /// Access control list applied to a stream.
     public enum Acl: Codable, Sendable {
         public typealias RawValue = Data
 
+        /// JSON-encoded representation of the ACL, compatible with the KurrentDB stream metadata format.
         public var rawValue: Data {
             get throws {
                 let encoder = JSONEncoder()
@@ -115,8 +147,11 @@ extension StreamMetadata {
             }
         }
 
+        /// Applies the built-in `$userStreamAcl` policy.
         case userStream
+        /// Applies the built-in `$systemStreamAcl` policy.
         case systemStream
+        /// Applies a custom `StreamAcl` policy.
         case stream(StreamAcl)
 
         public init(from decoder: any Decoder) throws {
@@ -150,6 +185,7 @@ extension StreamMetadata {
         }
     }
 
+    /// Fine-grained role-based access control for a stream.
     public struct StreamAcl: Codable, Sendable {
         enum CodingKeys: String, CodingKey {
             case readRoles = "$r"
@@ -159,48 +195,68 @@ extension StreamMetadata {
             case metaWriteRoles = "$mw"
         }
 
-        // Roles and users permitted to read the stream.
+        /// Roles and users permitted to read the stream.
         public private(set) var readRoles: [String]?
 
-        // Roles and users permitted to write to the stream.
+        /// Roles and users permitted to write to the stream.
         public private(set) var writeRoles: [String]?
 
-        // Roles and users permitted to delete to the stream.
+        /// Roles and users permitted to delete the stream.
         public private(set) var deleteRoles: [String]?
 
-        // Roles and users permitted to read stream metadata.
+        /// Roles and users permitted to read stream metadata.
         public private(set) var metaReadRoles: [String]?
 
-        // Roles and users permitted to write stream metadata.
+        /// Roles and users permitted to write stream metadata.
         public private(set) var metaWriteRoles: [String]?
     }
 }
 
 extension StreamMetadata.StreamAcl: Buildable {
+    /// Sets the roles permitted to read the stream.
+    ///
+    /// - Parameter roles: Array of role or username strings.
+    /// - Returns: An updated copy of the ACL.
     public func readRoles(_ roles: [String]) -> Self {
         withCopy { copied in
             copied.readRoles = roles
         }
     }
 
+    /// Sets the roles permitted to write to the stream.
+    ///
+    /// - Parameter roles: Array of role or username strings.
+    /// - Returns: An updated copy of the ACL.
     public func writeRoles(_ roles: [String]) -> Self {
         withCopy { copied in
             copied.writeRoles = roles
         }
     }
 
+    /// Sets the roles permitted to delete the stream.
+    ///
+    /// - Parameter roles: Array of role or username strings.
+    /// - Returns: An updated copy of the ACL.
     public func deleteRoles(_ roles: [String]) -> Self {
         withCopy { copied in
             copied.deleteRoles = roles
         }
     }
 
+    /// Sets the roles permitted to read stream metadata.
+    ///
+    /// - Parameter roles: Array of role or username strings.
+    /// - Returns: An updated copy of the ACL.
     public func metaReadRoles(_ roles: [String]) -> Self {
         withCopy { copied in
             copied.metaReadRoles = roles
         }
     }
 
+    /// Sets the roles permitted to write stream metadata.
+    ///
+    /// - Parameter roles: Array of role or username strings.
+    /// - Returns: An updated copy of the ACL.
     public func metaWriteRoles(_ roles: [String]) -> Self {
         withCopy { copied in
             copied.metaWriteRoles = roles

--- a/Sources/KurrentDB/Core/Stream/StreamPosition.swift
+++ b/Sources/KurrentDB/Core/Stream/StreamPosition.swift
@@ -7,10 +7,22 @@
 
 import Foundation
 
+/// Logical position of an event in the global `$all` stream.
+///
+/// A position is represented as a pair of monotonically increasing integers
+/// assigned by the server: `commit` and `prepare`.
 public struct StreamPosition: Sendable {
+    /// Commit position within the transaction log.
     public let commit: UInt64
+    /// Prepare position within the transaction log.
     public let prepare: UInt64
 
+    /// Creates a `StreamPosition` at the specified commit and prepare positions.
+    ///
+    /// - Parameters:
+    ///   - commitPosition: The commit position in the transaction log.
+    ///   - preparePosition: The prepare position in the transaction log. Defaults to `commitPosition` when omitted.
+    /// - Returns: A `StreamPosition` with the given coordinates.
     public static func at(commitPosition: UInt64, preparePosition: UInt64? = nil) -> Self {
         let preparePosition = preparePosition ?? commitPosition
         return .init(commit: commitPosition, prepare: preparePosition)

--- a/Sources/KurrentDB/Core/Stream/StreamRevisionRule.swift
+++ b/Sources/KurrentDB/Core/Stream/StreamRevisionRule.swift
@@ -7,9 +7,14 @@
 
 import Foundation
 
+/// Optimistic concurrency rule applied when appending events to a stream.
 public enum StreamRevision: Sendable {
+    /// No concurrency check — always append regardless of the current revision.
     case any
+    /// Requires the stream to not yet exist.
     case noStream
+    /// Requires the stream to already exist.
     case streamExists
+    /// Requires the stream's last event to be at the specified revision number.
     case at(UInt64)
 }

--- a/Sources/KurrentDB/Core/Stream/StreamSelector.swift
+++ b/Sources/KurrentDB/Core/Stream/StreamSelector.swift
@@ -5,7 +5,10 @@
 //  Created by Grady Zhuo on 2024/3/23.
 //
 
+/// Selects either all streams or a specific stream target of type `T`.
 public enum StreamSelector<T: Sendable>: Sendable {
+    /// Targets every stream, equivalent to operating on `$all`.
     case all
+    /// Targets a single stream identified by the associated value.
     case specified(T)
 }

--- a/Sources/KurrentDB/Core/SubscriptionFilter.swift
+++ b/Sources/KurrentDB/Core/SubscriptionFilter.swift
@@ -6,21 +6,45 @@
 //
 import GRPCEncapsulates
 
+/// Filter applied to a catch-up or persistent subscription to select a subset of events.
+///
+/// Use the static factory methods to create a filter, then chain builder methods to
+/// refine the checkpoint and window behaviour.
+///
+/// ```swift
+/// // Match streams whose name starts with "orders"
+/// let filter = SubscriptionFilter.onStreamName(prefix: "orders")
+///     .checkpointIntervalMultiplier(100)
+///
+/// // Match events whose type matches a regex
+/// let filter = SubscriptionFilter.onEventType(regex: "^OrderPlaced$")
+/// ```
 public struct SubscriptionFilter: Buildable {
+    /// Controls how many filtered events trigger a checkpoint.
     public enum Window: Sendable {
+        /// No upper-bound window; checkpointing is driven solely by `checkpointIntervalMultiplier`.
         case count
+        /// Checkpoint after at most `max` filtered events.
         case max(UInt32)
     }
 
+    /// Dimension on which the filter pattern is matched.
     public enum FilterType: Sendable {
+        /// Filter is applied to the stream name.
         case streamName
+        /// Filter is applied to the event type.
         case eventType
     }
 
+    /// Dimension used to match incoming events.
     public internal(set) var type: FilterType
+    /// Regular expression pattern, or `nil` when prefix matching is used instead.
     public internal(set) var regex: String?
+    /// Checkpoint window strategy.
     public internal(set) var window: Window
+    /// Prefix strings used when no regex is specified.
     public internal(set) var prefixes: [String]
+    /// Number of events between server-side checkpoints.
     public internal(set) var checkpointIntervalMultiplier: UInt32
 
     init(type: FilterType, regex: String? = nil, window: Window = .count, prefixes: [String] = []) {
@@ -31,6 +55,10 @@ public struct SubscriptionFilter: Buildable {
         checkpointIntervalMultiplier = .max
     }
 
+    /// Sets the maximum number of filtered events before a checkpoint is issued.
+    ///
+    /// - Parameter maxCount: Maximum event count between checkpoints.
+    /// - Returns: An updated copy of the filter.
     @discardableResult
     public func max(_ maxCount: UInt32) -> Self {
         withCopy { options in
@@ -38,6 +66,10 @@ public struct SubscriptionFilter: Buildable {
         }
     }
 
+    /// Sets the checkpoint interval multiplier used by the server.
+    ///
+    /// - Parameter multiplier: Multiplier applied to the server's base checkpoint interval.
+    /// - Returns: An updated copy of the filter.
     @discardableResult
     public func checkpointIntervalMultiplier(_ multiplier: UInt32) -> Self {
         withCopy { options in
@@ -45,6 +77,10 @@ public struct SubscriptionFilter: Buildable {
         }
     }
 
+    /// Appends an additional prefix to the filter's prefix list.
+    ///
+    /// - Parameter prefix: Stream name or event type prefix to include.
+    /// - Returns: An updated copy of the filter.
     @discardableResult
     public func add(prefix: String) -> Self {
         withCopy { options in
@@ -56,14 +92,30 @@ public struct SubscriptionFilter: Buildable {
 // MARK: - Constructor on StreamName
 
 extension SubscriptionFilter {
+    /// Creates a stream-name filter matching the given regular expression.
+    ///
+    /// - Parameter regex: Regular expression applied to each stream name.
+    /// - Returns: A configured `SubscriptionFilter`.
     public static func onStreamName(regex: String) -> Self {
         .init(type: .streamName, regex: regex)
     }
 
+    /// Creates a stream-name filter matching any of the given prefixes.
+    ///
+    /// ```swift
+    /// let filter = SubscriptionFilter.onStreamName(prefix: "orders", "payments")
+    /// ```
+    ///
+    /// - Parameter prefix: One or more stream name prefixes.
+    /// - Returns: A configured `SubscriptionFilter`.
     public static func onStreamName(prefix: String...) -> Self {
         .onStreamName(prefixes: prefix)
     }
 
+    /// Creates a stream-name filter matching any of the given prefixes.
+    ///
+    /// - Parameter prefixes: Array of stream name prefixes.
+    /// - Returns: A configured `SubscriptionFilter`.
     public static func onStreamName(prefixes: [String]) -> Self {
         .init(type: .streamName, prefixes: prefixes)
     }
@@ -72,14 +124,30 @@ extension SubscriptionFilter {
 // MARK: - Constructor on EventType
 
 extension SubscriptionFilter {
+    /// Creates an event-type filter matching the given regular expression.
+    ///
+    /// ```swift
+    /// let filter = SubscriptionFilter.onEventType(regex: "^OrderPlaced$")
+    /// ```
+    ///
+    /// - Parameter regex: Regular expression applied to each event type name.
+    /// - Returns: A configured `SubscriptionFilter`.
     public static func onEventType(regex: String) -> Self {
         .init(type: .eventType, regex: regex)
     }
 
+    /// Creates an event-type filter matching any of the given prefixes.
+    ///
+    /// - Parameter prefixes: One or more event type prefixes.
+    /// - Returns: A configured `SubscriptionFilter`.
     public static func onEventType(prefixes: String...) -> Self {
         .onEventType(prefixes: prefixes)
     }
 
+    /// Creates an event-type filter matching any of the given prefixes.
+    ///
+    /// - Parameter prefixes: Array of event type prefixes.
+    /// - Returns: A configured `SubscriptionFilter`.
     public static func onEventType(prefixes: [String]) -> Self {
         .init(type: .eventType, prefixes: prefixes)
     }
@@ -88,6 +156,9 @@ extension SubscriptionFilter {
 // MARK: - Constructor with excludeSystemEvents
 
 extension SubscriptionFilter {
+    /// Creates a stream-name filter that excludes all system streams (names starting with `$`).
+    ///
+    /// - Returns: A `SubscriptionFilter` configured to skip system streams.
     public static func excludeSystemEvents() -> Self {
         .onStreamName(regex: "^[^\\$].*")
     }

--- a/Sources/KurrentDB/Core/TimeSpan.swift
+++ b/Sources/KurrentDB/Core/TimeSpan.swift
@@ -7,7 +7,10 @@
 
 import Foundation
 
+/// Duration expressed in either .NET ticks or milliseconds.
 public enum TimeSpan: Sendable {
+    /// Duration in 100-nanosecond .NET ticks.
     case ticks(Int64)
+    /// Duration in milliseconds.
     case ms(Int32)
 }

--- a/Sources/KurrentDB/Core/UUIDOption.swift
+++ b/Sources/KurrentDB/Core/UUIDOption.swift
@@ -6,7 +6,10 @@
 //
 import Foundation
 
+/// Wire format used to encode UUIDs in gRPC messages.
 public enum UUIDOption: Sendable {
+    /// Encodes the UUID as two 64-bit integers (most-significant and least-significant bits).
     case structured
+    /// Encodes the UUID as a lowercase hyphenated string.
     case string
 }

--- a/Sources/KurrentDB/Gossip/Gossip.swift
+++ b/Sources/KurrentDB/Gossip/Gossip.swift
@@ -11,6 +11,7 @@ import GRPCNIOTransportHTTP2Posix
 import Logging
 import NIO
 
+/// Performs gossip protocol requests against a single Kurrent cluster endpoint.
 public final class Gossip: Sendable {
     package typealias UnderlyingClient = EventStore_Client_Gossip_Gossip.Client<HTTP2ClientTransport.Posix>
 
@@ -28,6 +29,14 @@ public final class Gossip: Sendable {
 }
 
 extension Gossip {
+    /// Reads the current member list from this endpoint's gossip API.
+    ///
+    /// Members whose state appears in `notAllowedStates` are excluded from the result.
+    /// The returned array is sorted by node preference priority as defined in `ClientSettings`.
+    ///
+    /// - Parameter notAllowedStates: Node states excluded from the result.
+    /// - Returns: An array of ``MemberInfo`` sorted by preference priority, excluding any disallowed states.
+    /// - Throws: `KurrentError` if the gRPC call fails or the response cannot be decoded.
     public func read(timeout _: Duration, notAllowedStates: [Gossip.VNodeState] = []) async throws(KurrentError) -> [MemberInfo] {
         let usecase = Read()
         return try await withRethrowingError(usage: "\(Self.self).\(#function)") {

--- a/Sources/KurrentDB/Gossip/KurrentDBClient+Gossip.swift
+++ b/Sources/KurrentDB/Gossip/KurrentDBClient+Gossip.swift
@@ -10,24 +10,19 @@
 extension KurrentDBClient {
     /// Reads the current cluster topology via the gossip protocol.
     ///
-    /// Returns information about all cluster members including their state (leader, follower,
-    /// readOnlyReplica), health status, and network endpoints.
+    /// Tries each configured endpoint in turn and returns the first successful member list.
+    /// Falls back to a direct call on the first candidate and rethrows any error if that also fails.
     ///
     /// ```swift
     /// let members = try await client.readCluster()
-    /// for member in members {
-    ///     print("Node \(member.instanceId): \(member.state), alive: \(member.isAlive)")
-    /// }
-    ///
-    /// // Find the current leader
     /// if let leader = members.first(where: { $0.state == .leader && $0.isAlive }) {
-    ///     print("Leader: \(leader.httpEndPoint)")
+    ///     print("Leader endpoint: \(leader.httpEndPoint)")
     /// }
     /// ```
     ///
-    /// - Parameter timeout: Maximum wait duration. Defaults to the client's configured gossip timeout.
-    /// - Returns: An array of ``Gossip/MemberInfo`` for all known cluster members.
-    /// - Throws: ``KurrentError`` if the gossip request fails or all endpoints are unreachable.
+    /// - Parameter timeout: Maximum wait per gossip request. Defaults to the client's configured gossip timeout.
+    /// - Returns: An array of ``Gossip/MemberInfo`` representing all known cluster members.
+    /// - Throws: `KurrentError` if the gossip request fails or all endpoints are unreachable.
     public func readCluster(timeout: Duration? = nil) async throws(KurrentError) -> [Gossip.MemberInfo] {
         let candidates = switch settings.clusterMode {
         case let .standalone(endpoint):

--- a/Sources/KurrentDB/Gossip/MemberInfo.swift
+++ b/Sources/KurrentDB/Gossip/MemberInfo.swift
@@ -2,13 +2,19 @@ import Foundation
 import GRPCEncapsulates
 
 extension Gossip {
+    /// Snapshot of a single cluster member as reported by the gossip protocol.
     public struct MemberInfo: GRPCResponse {
         package typealias UnderlyingMessage = EventStore_Client_Gossip_MemberInfo
 
+        /// Unique identifier for this node instance.
         public let instanceId: UUID
+        /// Timestamp of the gossip report, expressed as seconds since the Unix epoch.
         public let timeStamp: TimeInterval
+        /// Current lifecycle state of this node.
         public let state: VNodeState
+        /// Indicates whether this node is currently healthy and reachable.
         public let isAlive: Bool
+        /// HTTP endpoint used to communicate with this node.
         public let httpEndPoint: Endpoint
 
         init(instanceId: UUID, timeStamp: TimeInterval, state: VNodeState, isAlive: Bool, httpEndPoint: Endpoint) {

--- a/Sources/KurrentDB/Gossip/VNodeState.swift
+++ b/Sources/KurrentDB/Gossip/VNodeState.swift
@@ -2,25 +2,43 @@ import Foundation
 import GRPCEncapsulates
 
 extension Gossip {
+    /// Represents the lifecycle state of a virtual node (VNode) in the Kurrent cluster.
     public enum VNodeState: Sendable, Equatable {
         package typealias UnderlyingMessage = EventStore_Client_Gossip_MemberInfo.VNodeState
 
+        /// Node is starting up and not yet ready to serve requests.
         case initializing
+        /// Node is searching for the current cluster leader.
         case discoverLeader
+        /// Node state cannot be determined.
         case unknown
+        /// Node is preparing to become a replica before full replication begins.
         case preReplica
+        /// Node is catching up by replicating historical data from the leader.
         case catchingUp
+        /// Legacy node role: replicated data from the leader without participating in quorum. Superseded by ``readOnlyReplica``.
         case clone
+        /// Node is a fully synchronized follower replicating from the leader.
         case follower
+        /// Node is transitioning to become the cluster leader.
         case preLeader
+        /// Node is the active cluster leader accepting all writes.
         case leader
+        /// Node is operating as a cluster manager.
         case manager
+        /// Node has begun its shutdown sequence and is winding down.
         case shuttingDown
+        /// Node has fully stopped and is no longer serving requests.
         case shutdown
+        /// Read-only replica that has lost contact with the leader; replication is paused and reads may be stale.
         case readOnlyLeaderless
+        /// Node is preparing to become a read-only replica.
         case preReadOnlyReplica
+        /// Node is a read-only replica, accepting reads but not writes.
         case readOnlyReplica
+        /// Node is actively stepping down from the leader role.
         case resigningLeader
+        /// Node state value not recognized by this client version.
         case UNRECOGNIZED(Int)
 
         package init(from message: UnderlyingMessage) {

--- a/Sources/KurrentDB/KurrentDBClient.swift
+++ b/Sources/KurrentDB/KurrentDBClient.swift
@@ -13,84 +13,49 @@ import NIO
 import NIOSSL
 import Synchronization
 
-/// The primary entry point for interacting with a KurrentDB cluster.
+/// Primary entry point for interacting with a KurrentDB cluster.
 ///
-/// `KurrentDBClient` provides a high-level, type-safe interface for all KurrentDB operations.
-/// Access different subsystems through factory methods and properties:
-///
-/// | Subsystem | Access |
-/// |-----------|--------|
-/// | Streams | `streams(specified:)`, `allStreams`, `multiStreams` |
-/// | Projections | `projections(name:)`, `projections(system:)` |
-/// | Persistent Subscriptions | `persistentSubscriptions(stream:group:)`, `allPersistentSubscriptions` |
-/// | Users | `users`, `user(_:)` |
-/// | Operations | `operations(of:)` |
-/// | Monitoring | `monitoring`, `stats()` |
-/// | Gossip | `readCluster()` |
-///
-/// ## Usage
+/// Access subsystems through factory methods and computed properties, then perform async operations
+/// on the returned value.
 ///
 /// ```swift
-/// let client = KurrentDBClient(settings: .localhost()
-///     .authenticated(.credentials(username: "admin", password: "changeit")))
+/// let client = KurrentDBClient(
+///     settings: .localhost()
+///         .authenticated(.credentials(username: "admin", password: "changeit"))
+/// )
 ///
-/// // Append events
-/// try await client.streams(specified: "orders").append(events: [
-///     EventData(eventType: "OrderCreated", model: order)
-/// ])
+/// // Append to a specific stream
+/// try await client.streams(specified: "orders").append(events: events)
 ///
-/// // Read from $all
-/// for try await response in try await client.allStreams.read() {
-///     print(response)
+/// // Read from the global $all stream
+/// for try await event in try await client.allStreams.read() {
+///     print(event)
 /// }
 /// ```
 ///
-/// Connections are managed internally via ``NodeSelector``, which handles cluster discovery,
-/// leader/follower preference, and automatic reconnection based on ``ClientSettings``.
-///
-/// - SeeAlso: ``ClientSettings``, ``KurrentDBClientProtocol``, ``Streams``, ``Projections``
+/// - SeeAlso: ``ClientSettings``, ``KurrentDBClientProtocol``
 public final class KurrentDBClient: Sendable, Buildable {
-    
-    /// Default gRPC call options applied to all operations performed through this client.
-    ///
-    /// Controls timeouts, custom metadata, and compression for gRPC calls. Configure during
-    /// initialization for consistency:
-    ///
-    /// ```swift
-    /// let client = KurrentDBClient(
-    ///     settings: settings,
-    ///     defaultCallOptions: callOptions
-    /// )
-    /// ```
+
+    /// Default gRPC call options applied to every request made through this client.
     public let defaultCallOptions: CallOptions
 
-    /// Connection settings including cluster endpoints, authentication, TLS, and discovery configuration.
-    ///
-    /// Immutable after initialization. To change settings, create a new client instance.
-    ///
-    /// - SeeAlso: ``ClientSettings``
+    /// Connection and authentication settings used by this client.
     public let settings: ClientSettings
 
-    /// The event loop group used for asynchronous I/O operations.
-    ///
-    /// This event loop group manages network connections and handles concurrent requests.
-    /// It can either be created internally or shared with the application.
+    /// Event loop group that drives all asynchronous network I/O for this client.
     package let eventLoopGroup: EventLoopGroup
 
-    /// The node selector responsible for cluster discovery and endpoint selection.
-    ///
-    /// Handles routing requests to appropriate cluster nodes based on node preference
-    /// (leader, follower, or random) and maintains connection health.
+    /// Node selector that performs cluster discovery and routes requests to the best node.
     package let selector: NodeSelector
 
     private let isShutdown = Mutex<Bool>(false)
 
-    /// Creates a new client with an internally managed event loop group.
+    /// Creates a client that manages its own event loop group.
     ///
     /// - Parameters:
     ///   - settings: Connection and authentication configuration. Use `.localhost()` for local development.
-    ///   - numberOfThreads: Thread count for the event loop group. Defaults to `1`.
-    ///   - defaultCallOptions: gRPC call options applied to all requests. Defaults to `.defaults`.
+    ///   - numberOfThreads: Number of threads to allocate for the internal event loop group. Defaults to `1`.
+    ///   - defaultCallOptions: gRPC call options applied to all outgoing requests. Defaults to `.defaults`.
     public init(settings: ClientSettings, numberOfThreads: Int = 1, defaultCallOptions: CallOptions = .defaults) {
         self.defaultCallOptions = defaultCallOptions
         self.settings = settings
@@ -98,15 +63,12 @@ public final class KurrentDBClient: Sendable, Buildable {
         self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: numberOfThreads)
     }
 
-    /// Creates a new client using an externally managed event loop group.
-    ///
-    /// Use this when sharing an `EventLoopGroup` across multiple clients or SwiftNIO services.
+    /// Creates a client sharing an externally owned event loop group.
     ///
     /// - Parameters:
     ///   - settings: Connection and authentication configuration.
-    ///   - eventLoopGroup: An existing event loop group. The caller retains ownership and must
-    ///     keep it alive for the lifetime of this client.
-    ///   - defaultCallOptions: gRPC call options applied to all requests. Defaults to `.defaults`.
+    ///   - eventLoopGroup: An existing event loop group whose lifetime the caller manages.
+    ///   - defaultCallOptions: gRPC call options applied to all outgoing requests. Defaults to `.defaults`.
     private init(settings: ClientSettings, eventLoopGroup: EventLoopGroup, defaultCallOptions: CallOptions = .defaults) {
         self.defaultCallOptions = defaultCallOptions
         self.settings = settings
@@ -130,10 +92,11 @@ public final class KurrentDBClient: Sendable, Buildable {
 }
 
 extension KurrentDBClient {
-    /// Shuts down the client's event loop group, releasing all network resources.
+    /// Shuts down the internal event loop group and releases all network resources.
     ///
-    /// Call this when you are done with the client and it was created with the default
-    /// initializer (i.e., not sharing an external `EventLoopGroup`). Safe to call multiple times.
+    /// Safe to call multiple times. Has no effect if the client was already shut down or deinitialized.
+    ///
+    /// - Throws: Any error raised by the underlying NIO `syncShutdownGracefully()`.
     public func shutdown() throws {
         isShutdown.withLock { $0 = true }
         try eventLoopGroup.syncShutdownGracefully()

--- a/Sources/KurrentDB/KurrentDBClientProtocol.swift
+++ b/Sources/KurrentDB/KurrentDBClientProtocol.swift
@@ -5,11 +5,10 @@
 //  Created by Grady Zhuo on 2026/2/25.
 //
 
-/// A protocol mirroring all public factory methods on ``KurrentDBClient``.
+/// Abstraction over ``KurrentDBClient`` that enables dependency injection and test doubles.
 ///
-/// Conform to this protocol in test doubles to enable dependency injection without depending
-/// on a live client. ``KurrentDBClient`` itself conforms, so production code can accept
-/// `any KurrentDBClientProtocol` and tests can substitute a mock.
+/// Production code that accepts `any KurrentDBClientProtocol` can be tested by substituting a
+/// mock without depending on a live server. ``KurrentDBClient`` conforms to this protocol.
 ///
 /// ```swift
 /// struct OrderService {
@@ -27,51 +26,77 @@ public protocol KurrentDBClientProtocol: Sendable {
 
     // MARK: - Streams
 
-    /// Creates a streams interface for the given target (`.specified(_:)`, `.all`, `.multiple`).
+    /// Returns a streams interface scoped to the given target.
+    ///
+    /// - Parameter target: The stream target (`.specified(_:)`, `.all`, or `.multiple`).
+    /// - Returns: A ``Streams`` instance bound to `Target`.
     func streams<Target: StreamsTarget>(of target: Target) -> Streams<Target>
 
-    /// Creates a streams interface for a specific stream by name.
+    /// Returns a streams interface scoped to a single named stream.
+    ///
+    /// - Parameter name: The stream name.
+    /// - Returns: A ``Streams`` instance scoped to the specified stream.
     func streams(specified name: String) -> Streams<SpecifiedStream>
 
-    /// The `$all` stream for global event log operations (read, subscribe).
+    /// Streams interface for the global `$all` stream.
     var allStreams: Streams<AllStreamsTarget> { get }
 
-    /// Batch operations across multiple streams (requires server 25.1+).
+    /// Streams interface for batch operations across multiple streams (requires server 25.1+).
     var multiStreams: Streams<MultiStreamsTarget> { get }
 
     // MARK: - Persistent Subscriptions
 
-    /// Cluster-wide persistent subscription operations (list, restart subsystem).
+    /// Persistent subscriptions interface for cluster-wide operations such as listing all subscriptions.
     var allPersistentSubscriptions: PersistentSubscriptions<AllPersistentSubscriptionTarget> { get }
 
-    /// Creates a persistent subscriptions interface for a specific target type.
+    /// Returns a persistent subscriptions interface for the given target.
+    ///
+    /// - Parameter target: The persistent subscription target.
+    /// - Returns: A ``PersistentSubscriptions`` instance bound to `Target`.
     func persistentSubscriptions<Target: PersistentSubscriptionTarget>(of target: Target) -> PersistentSubscriptions<Target>
 
-    /// Creates a persistent subscriptions interface for a specific stream and consumer group.
+    /// Returns a persistent subscriptions interface scoped to a specific stream and consumer group.
+    ///
+    /// - Parameters:
+    ///   - stream: The stream name the subscription reads from.
+    ///   - group: The consumer group name.
+    /// - Returns: A ``PersistentSubscriptions`` instance for the specified stream and group.
     func persistentSubscriptions(stream: String, group: String) -> PersistentSubscriptions<SpecifiedPersistentSubscriptionTarget>
 
-    /// Persistent subscriptions filtered by consumer group name across all streams.
+    /// Returns a persistent subscriptions interface for the `$all` stream scoped to a specific consumer group.
+    ///
+    /// - Parameter groupName: The consumer group name to filter by.
+    /// - Returns: A ``PersistentSubscriptions`` instance targeting the `$all` stream for the given group.
     func persistentSubscriptions(filterGroup groupName: String) -> PersistentSubscriptions<AllStreamPersistentSubscriptionTarget>
 
-    /// Persistent subscriptions filtered by stream name.
+    /// Returns a persistent subscriptions interface filtered to subscriptions on a specific stream.
+    ///
+    /// - Parameter stream: The stream name to filter by.
+    /// - Returns: A ``PersistentSubscriptions`` instance scoped to the given stream.
     func persistentSubscriptions(filterStream stream: String) -> PersistentSubscriptions<FilterStreamPersistentSubscriptionTarget>
 
     // MARK: - Users
 
-    /// User management service for cluster-wide operations (create, list).
+    /// User management interface for cluster-wide operations such as creating and listing users.
     var users: Users<AllUsersTarget> { get }
 
-    /// User interface scoped to a specific user by login name.
+    /// Returns a user management interface scoped to a single user.
+    ///
+    /// - Parameter loginName: The login name of the user.
+    /// - Returns: A ``Users`` instance scoped to the specified user.
     func user(_ loginName: String) -> Users<SpecifiedUserTarget>
 
     // MARK: - Server Operations
 
-    /// Server operations interface for the given target (`.system`, `.scavenge`, `.node`).
+    /// Returns a server operations interface for the given target.
+    ///
+    /// - Parameter target: The operations target (e.g., scavenge, node operations).
+    /// - Returns: An ``Operations`` instance bound to `Target`.
     func operations<Target: OperationsTarget>(of target: Target) -> Operations<Target>
 
     // MARK: - Monitoring
 
-    /// Cluster monitoring service for health checks and server statistics.
+    /// Monitoring interface for cluster health checks and server statistics.
     var monitoring: Monitoring { get }
 }
 

--- a/Sources/KurrentDB/Monitoring/KurrentDBClient+Monitoring.swift
+++ b/Sources/KurrentDB/Monitoring/KurrentDBClient+Monitoring.swift
@@ -8,21 +8,12 @@
 // MARK: - Monitoring Operations
 
 extension KurrentDBClient {
-    /// Accesses the cluster monitoring service for health checks and status information.
-    ///
-    /// ```swift
-    /// let health = try await client.monitoring.health()
-    /// ```
-    ///
-    /// - SeeAlso: ``Monitoring``
+    /// Monitoring service for querying real-time KurrentDB server statistics.
     public var monitoring: Monitoring {
         .init(selector: selector, callOptions: defaultCallOptions, eventLoopGroup: eventLoopGroup)
     }
 
-    /// Retrieves real-time server statistics as an asynchronous stream.
-    ///
-    /// Each snapshot contains key-value pairs of server metrics (disk usage, memory, queue lengths, etc.)
-    /// refreshed at the specified interval.
+    /// Streams server statistics snapshots from the monitoring service.
     ///
     /// ```swift
     /// for try await snapshot in try await client.stats() {
@@ -33,10 +24,11 @@ extension KurrentDBClient {
     /// ```
     ///
     /// - Parameters:
-    ///   - useMetadata: Include metadata in the response. Defaults to `false`.
-    ///   - refreshTimePeriodInMs: Refresh interval in milliseconds. Defaults to `10000` (10s).
-    ///
+    ///   - useMetadata: Include metadata fields in each snapshot. Defaults to `false`.
+    ///   - refreshTimePeriodInMs: Interval between snapshots in milliseconds. Defaults to `10000` (10 s).
     /// - Returns: An async stream of ``Monitoring/Stats/Response`` snapshots.
+    /// - Throws: `KurrentError.accessDenied` if the caller lacks permission to read stats.
+    ///   `KurrentError.unavailable` if the server cannot be reached.
     public func stats(useMetadata: Bool = false, refreshTimePeriodInMs: UInt64 = 10000) async throws(KurrentError) -> Monitoring.Stats.Responses {
         let monitoring = Monitoring(selector: selector, callOptions: defaultCallOptions, eventLoopGroup: eventLoopGroup)
         return try await monitoring.stats(useMetadata: useMetadata, refreshTimePeriodInMs: refreshTimePeriodInMs)

--- a/Sources/KurrentDB/Monitoring/Monitoring.swift
+++ b/Sources/KurrentDB/Monitoring/Monitoring.swift
@@ -12,6 +12,7 @@ import GRPCNIOTransportHTTP2Posix
 import Logging
 import NIO
 
+/// gRPC service for retrieving real-time KurrentDB server statistics.
 public final class Monitoring: GRPCConcreteService {
     package typealias UnderlyingClient = EventStore_Client_Monitoring_Monitoring.Client<HTTP2ClientTransport.Posix>
 
@@ -27,6 +28,14 @@ public final class Monitoring: GRPCConcreteService {
 }
 
 extension Monitoring {
+    /// Streams server statistics snapshots at the specified refresh interval.
+    ///
+    /// - Parameters:
+    ///   - useMetadata: Include metadata fields in each stats snapshot. Defaults to `false`.
+    ///   - refreshTimePeriodInMs: Interval between snapshots in milliseconds. Defaults to `10000` (10 s).
+    /// - Returns: An async stream of ``Stats/Response`` snapshots.
+    /// - Throws: `KurrentError.accessDenied` if the caller lacks permission to read stats.
+    ///   `KurrentError.unavailable` if the server cannot be reached.
     public func stats(useMetadata: Bool = false, refreshTimePeriodInMs: UInt64 = 10000) async throws(KurrentError) -> Stats.Responses {
         let node = try await selector.select()
         let usecase = Stats(useMetadata: useMetadata, refreshTimePeriodInMs: refreshTimePeriodInMs)

--- a/Sources/KurrentDB/Monitoring/Usecase/Monitoring.Stats.swift
+++ b/Sources/KurrentDB/Monitoring/Usecase/Monitoring.Stats.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Monitoring {
+    /// Usecase that opens a server-streaming stats RPC and yields periodic snapshots.
     public struct Stats: UnaryStream {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.Stats.Input
@@ -23,7 +24,9 @@ extension Monitoring {
             "Monitoring.\(Self.self)"
         }
 
+        /// Whether to include metadata fields in each stats snapshot.
         public let useMetadata: Bool
+        /// Interval between consecutive snapshots in milliseconds.
         public let refreshTimePeriodInMs: UInt64
 
         public init(useMetadata: Bool = false, refreshTimePeriodInMs: UInt64 = 10000) {
@@ -72,9 +75,11 @@ extension Monitoring {
 }
 
 extension Monitoring.Stats {
+    /// Single server statistics snapshot decoded from a gRPC response message.
     public struct Response: GRPCResponse {
         package typealias UnderlyingMessage = UnderlyingResponse
 
+        /// Key-value map of server metric names to their current values.
         public var stats: [String: String]
 
         package init(from message: UnderlyingMessage) throws {

--- a/Sources/KurrentDB/Operations/KurrentDBClient+ServerOperations.swift
+++ b/Sources/KurrentDB/Operations/KurrentDBClient+ServerOperations.swift
@@ -19,10 +19,8 @@ extension KurrentDBClient {
     /// ```swift
     /// try await client.operations(of: .system).mergeIndexes()
     ///
-    /// let response = try await client.operations(of: .scavenge)
-    ///     .startScavenge(threadCount: 2, startFromChunk: 0)
-    /// try await client.operations(of: .activeScavenge(scavengeId: response.scavengeId))
-    ///     .stopScavenge()
+    /// let response = try await client.operations(of: ScavengeOperations()).startScavenge()
+    /// // scavenge started
     /// ```
     ///
     /// - Parameter target: Operations target specifying scope and capabilities.

--- a/Sources/KurrentDB/Operations/KurrentDBClient+ServerOperations.swift
+++ b/Sources/KurrentDB/Operations/KurrentDBClient+ServerOperations.swift
@@ -8,9 +8,9 @@
 // MARK: - Server Operations Factory Methods
 
 extension KurrentDBClient {
-    /// Creates a server operations interface for the specified target.
+    /// Returns a server operations interface scoped to the given target.
     ///
-    /// The target determines which operations are available at compile time:
+    /// The target constrains which operations are available at compile time:
     /// - `.system` — `shutdown()`, `mergeIndexes()`, `restartPersistentSubscriptions()`
     /// - `.scavenge` — `startScavenge(threadCount:startFromChunk:)`
     /// - `.activeScavenge(scavengeId:)` — `stopScavenge()`
@@ -25,8 +25,8 @@ extension KurrentDBClient {
     ///     .stopScavenge()
     /// ```
     ///
-    /// - Parameter target: The operations target specifying scope and available operations.
-    /// - Returns: A configured ``Operations`` instance constrained by the target type.
+    /// - Parameter target: Operations target specifying scope and capabilities.
+    /// - Returns: An ``Operations`` instance constrained by the target type.
     public func operations<Target: OperationsTarget>(of target: Target) -> Operations<Target> {
         .init(target: target, selector: selector, callOptions: defaultCallOptions, eventLoopGroup: eventLoopGroup)
     }

--- a/Sources/KurrentDB/Operations/Operations.swift
+++ b/Sources/KurrentDB/Operations/Operations.swift
@@ -12,63 +12,17 @@ import GRPCNIOTransportHTTP2Posix
 import Logging
 import NIO
 
-/// A gRPC service for managing KurrentDB server operations with type-safe target-based operations.
-///
-/// `Operations` provides a type-safe interface for server administrative tasks using target-based design.
-/// Different operations are available depending on the target type:
-///
-/// ## Target Types
-///
-/// - **ScavengeOperations**: Start new scavenge operations
-/// - **ActiveScavenge**: Control specific running scavenge operations
-/// - **SystemOperations**: System-wide administrative tasks
-/// - **NodeOperations**: Cluster node management
-///
-/// ## Usage
-///
-/// Starting a scavenge operation:
-/// ```swift
-/// let scavenges = Operations(target: ScavengeOperations(), selector: selector, ...)
-/// let response = try await scavenges.startScavenge(threadCount: 4, startFromChunk: 0)
-/// print("Scavenge started with ID: \(response.scavengeId)")
-/// ```
-///
-/// Stopping a specific scavenge:
-/// ```swift
-/// let active = Operations(target: ActiveScavenge(scavengeId: "abc123"), ...)
-/// try await active.stopScavenge()
-/// ```
-///
-/// System operations:
-/// ```swift
-/// let system = Operations(target: SystemOperations(), ...)
-/// try await system.shutdown()
-/// ```
-///
-/// - Note: This service relies on **gRPC** and requires proper authentication.
+/// gRPC service for KurrentDB server administration scoped to a specific operations target.
 public final class Operations<Target: OperationsTarget>: GRPCConcreteService {
-    /// The underlying client type used for gRPC communication.
     package typealias UnderlyingClient = EventStore_Client_Operations_Operations.Client<HTTP2ClientTransport.Posix>
 
-    /// The node selector for routing requests to cluster nodes.
     internal let selector: NodeSelector
-
-    /// Options to be used for each gRPC service call.
     internal let callOptions: CallOptions
-
-    /// The event loop group for asynchronous execution.
     internal let eventLoopGroup: EventLoopGroup
 
-    /// The target specifying which operations this service can perform.
+    /// Target specifying the scope and available operations for this service instance.
     public let target: Target
 
-    /// Initializes an `Operations` instance with a specific target.
-    ///
-    /// - Parameters:
-    ///   - target: The operations target specifying the scope of operations.
-    ///   - selector: The node selector for cluster node routing.
-    ///   - callOptions: Options for the gRPC call, defaulting to `.defaults`.
-    ///   - eventLoopGroup: The event loop group for async operations, defaulting to `.singletonMultiThreadedEventLoopGroup`.
     init(target: Target, selector: NodeSelector, callOptions: CallOptions = .defaults, eventLoopGroup: EventLoopGroup = .singletonMultiThreadedEventLoopGroup) {
         self.target = target
         self.selector = selector
@@ -80,22 +34,15 @@ public final class Operations<Target: OperationsTarget>: GRPCConcreteService {
 // MARK: - Scavenge Creation Operations
 
 extension Operations where Target: ScavengeCreatable {
-    /// Starts a scavenge operation to reclaim disk space.
-    ///
-    /// Scavenging removes deleted events from database chunks, freeing disk space and
-    /// improving read performance. The operation runs asynchronously on the server.
+    /// Starts a scavenge operation to reclaim disk space by removing deleted events.
     ///
     /// - Parameters:
-    ///   - threadCount: The number of parallel threads to use for scavenging. Higher values
-    ///     complete faster but increase server load. Typical range: 1-4.
-    ///   - startFromChunk: The chunk number to begin scavenging from. Use 0 to start from
-    ///     the beginning, or specify a chunk number to resume a previously interrupted scavenge.
-    ///
-    /// - Returns: A response containing the unique scavenge ID and initial status.
-    ///
-    /// - Throws: `KurrentError.accessDenied` if the user lacks administrative permissions.
+    ///   - threadCount: Number of parallel threads to use; higher values are faster but increase load.
+    ///   - startFromChunk: Chunk number to start from; use `0` to begin at the first chunk.
+    /// - Returns: A response containing the scavenge ID and initial status.
+    /// - Throws: `KurrentError.accessDenied` if the caller lacks administrative permissions.
     ///   `KurrentError.alreadyExists` if a scavenge is already running.
-    ///   `KurrentError.invalidArgument` if parameters are invalid.
+    ///   `KurrentError.invalidArgument` if parameters are out of range.
     public func startScavenge(threadCount: Int32, startFromChunk: Int32) async throws(KurrentError) -> StartScavenge.Response {
         let node = try await selector.select()
         let usecase = StartScavenge(threadCount: threadCount, startFromChunk: startFromChunk)
@@ -106,15 +53,11 @@ extension Operations where Target: ScavengeCreatable {
 // MARK: - Scavenge Control Operations
 
 extension Operations where Target: ScavengeControllable {
-    /// Stops the target scavenge operation gracefully.
+    /// Stops the target scavenge operation, saving its position for potential resumption.
     ///
-    /// Stops the identified scavenge operation, allowing it to complete its current chunk
-    /// before halting. The scavenge position is saved for potential resumption.
-    ///
-    /// - Returns: A response containing the final status and position of the stopped scavenge.
-    ///
-    /// - Throws: `KurrentError.notFound` if no scavenge exists with the target ID.
-    ///   `KurrentError.accessDenied` if the user lacks administrative permissions.
+    /// - Returns: A response containing the final status and chunk position.
+    /// - Throws: `KurrentError.notFound` if no running scavenge matches the target ID.
+    ///   `KurrentError.accessDenied` if the caller lacks administrative permissions.
     public func stopScavenge() async throws(KurrentError) -> StopScavenge.Response {
         let node = try await selector.select()
         let usecase = StopScavenge(scavengeId: target.scavengeId)
@@ -125,12 +68,9 @@ extension Operations where Target: ScavengeControllable {
 // MARK: - System Operations
 
 extension Operations where Target: SystemControllable {
-    /// Merges database indexes to optimize query performance.
+    /// Merges database index segments to reduce disk I/O and improve query performance.
     ///
-    /// Index merging consolidates index segments, reducing disk I/O and improving
-    /// query performance. This operation can be resource-intensive.
-    ///
-    /// - Throws: `KurrentError.accessDenied` if the user lacks administrative permissions.
+    /// - Throws: `KurrentError.accessDenied` if the caller lacks administrative permissions.
     ///   `KurrentError.unavailable` if the operation cannot be performed.
     public func mergeIndexes() async throws(KurrentError) {
         let node = try await selector.select()
@@ -138,12 +78,9 @@ extension Operations where Target: SystemControllable {
         _ = try await usecase.perform(node: node, callOptions: callOptions)
     }
 
-    /// Restarts the persistent subscriptions subsystem.
+    /// Restarts the persistent subscriptions subsystem, reloading all subscription groups from storage.
     ///
-    /// Stops all persistent subscriptions, clears in-memory state, and reinitializes
-    /// the subscription manager. All subscription groups reload from persistent storage.
-    ///
-    /// - Throws: `KurrentError.accessDenied` if the user lacks administrative permissions.
+    /// - Throws: `KurrentError.accessDenied` if the caller lacks administrative permissions.
     ///   `KurrentError.unavailable` if the subsystem cannot be restarted.
     public func restartPersistentSubscriptions() async throws(KurrentError) {
         let node = try await selector.select()
@@ -151,15 +88,10 @@ extension Operations where Target: SystemControllable {
         _ = try await usecase.perform(node: node, callOptions: callOptions)
     }
 
-    /// Shuts down the KurrentDB server gracefully.
+    /// Initiates a graceful server shutdown.
     ///
-    /// Initiates a graceful shutdown, completing in-flight operations and persisting
-    /// state before terminating the server process.
-    ///
-    /// - Throws: `KurrentError.accessDenied` if the user lacks administrative permissions.
-    ///
-    /// - Warning: This operation terminates the server. Ensure all clients are prepared
-    ///   for disconnection.
+    /// - Throws: `KurrentError.accessDenied` if the caller lacks administrative permissions.
+    /// - Warning: Terminates the server process. Ensure all clients are prepared for disconnection.
     public func shutdown() async throws(KurrentError) {
         let node = try await selector.select()
         let usecase = Shutdown()
@@ -170,12 +102,9 @@ extension Operations where Target: SystemControllable {
 // MARK: - Node Operations
 
 extension Operations where Target: NodeControllable {
-    /// Resigns the current node from its role in the cluster.
+    /// Resigns the current node from its cluster role, triggering a new election if it is leader.
     ///
-    /// If the node is a leader, it steps down and triggers a new election. This is useful
-    /// for graceful maintenance or cluster rebalancing.
-    ///
-    /// - Throws: `KurrentError.accessDenied` if the user lacks administrative permissions.
+    /// - Throws: `KurrentError.accessDenied` if the caller lacks administrative permissions.
     ///   `KurrentError.unavailable` if the operation cannot be performed.
     public func resignNode() async throws(KurrentError) {
         let node = try await selector.select()
@@ -183,14 +112,10 @@ extension Operations where Target: NodeControllable {
         _ = try await usecase.perform(node: node, callOptions: callOptions)
     }
 
-    /// Sets the priority of the current node for leader election.
+    /// Sets the current node's election priority; higher values increase the chance of becoming leader.
     ///
-    /// Higher priority nodes are more likely to be elected as leader. Use this to
-    /// influence cluster leadership distribution.
-    ///
-    /// - Parameter priority: The priority value to set. Higher values increase election likelihood.
-    ///
-    /// - Throws: `KurrentError.accessDenied` if the user lacks administrative permissions.
+    /// - Parameter priority: Priority value for leader election.
+    /// - Throws: `KurrentError.accessDenied` if the caller lacks administrative permissions.
     ///   `KurrentError.invalidArgument` if the priority value is invalid.
     public func setNodePriority(priority: Int32) async throws(KurrentError) {
         let node = try await selector.select()

--- a/Sources/KurrentDB/Operations/OperationsTarget.swift
+++ b/Sources/KurrentDB/Operations/OperationsTarget.swift
@@ -5,119 +5,32 @@
 //  Created by Grady Zhuo on 2026/2/15.
 //
 
-/// A protocol representing a target for server operations in KurrentDB.
-///
-/// A **target** serves two key purposes in the Operations API:
-///
-/// ## 1. Specifies the Operation Scope (Where)
-///
-/// The target identifies what the operation applies to:
-/// - `ScavengeOperations`: Scavenge-related operations (start new scavenge)
-/// - `ActiveScavenge`: A specific running scavenge operation (stop specific scavenge)
-/// - `SystemOperations`: System-wide operations (shutdown, merge indexes, restart subsystems)
-/// - `NodeOperations`: Current node operations (resign, set priority)
-///
-/// ## 2. Constrains Available Operations (What)
-///
-/// Through protocol composition, different target types enable different capabilities:
-/// - Targets conforming to `ScavengeCreatable` can start new scavenge operations
-/// - Targets conforming to `ScavengeControllable` can stop specific scavenge operations
-/// - Targets conforming to `SystemControllable` can perform system-wide operations
-/// - Targets conforming to `NodeControllable` can manage node behavior
-/// - The type system prevents invalid operations at compile time
-///
-/// ## Type Safety
-///
-/// This design provides compile-time guarantees that operations are only performed on appropriate targets:
-///
-/// ```swift
-/// // Target specifies: scavenge operations (where)
-/// // Target constrains: can start new scavenge (what)
-/// let scavenges = Operations(target: ScavengeOperations(), ...)
-/// let response = try await scavenges.startScavenge(threadCount: 2, startFromChunk: 0)
-/// try await scavenges.stopScavenge(scavengeId: "...")  // ✗ Compile error - no such method
-///
-/// // Target specifies: specific active scavenge (where)
-/// // Target constrains: can stop this scavenge (what)
-/// let activeScavenge = Operations(target: ActiveScavenge(scavengeId: "abc123"), ...)
-/// try await activeScavenge.stopScavenge()              // ✓ Allowed
-/// try await activeScavenge.startScavenge(...)          // ✗ Compile error - no such method
-///
-/// // Target specifies: system operations (where)
-/// // Target constrains: can perform system tasks (what)
-/// let system = Operations(target: SystemOperations(), ...)
-/// try await system.shutdown()                          // ✓ Allowed
-/// try await system.mergeIndexes()                      // ✓ Allowed
-/// try await system.restartPersistentSubscriptions()    // ✓ Allowed
-///
-/// // Target specifies: current node (where)
-/// // Target constrains: can manage node (what)
-/// let node = Operations(target: NodeOperations(), ...)
-/// try await node.resignNode()                          // ✓ Allowed
-/// try await node.setNodePriority(priority: 10)         // ✓ Allowed
-/// ```
-///
-/// ## Usage
-///
-/// Create targets using specific constructors:
-///
-/// ```swift
-/// // For starting new scavenges
-/// let scavenges = Operations(target: ScavengeOperations(), ...)
-/// try await scavenges.startScavenge(threadCount: 2, startFromChunk: 0)
-///
-/// // For controlling a specific scavenge
-/// let active = Operations(target: ActiveScavenge(scavengeId: "abc123"), ...)
-/// try await active.stopScavenge()
-///
-/// // For system operations
-/// let system = Operations(target: SystemOperations(), ...)
-/// try await system.shutdown()
-///
-/// // For node operations
-/// let node = Operations(target: NodeOperations(), ...)
-/// try await node.resignNode()
-///
-/// // Or use KurrentDBClient convenience methods (recommended)
-/// try await client.startScavenge(threadCount: 2, startFromChunk: 0)
-/// try await client.stopScavenge(scavengeId: "abc123")
-/// ```
-///
-/// ## Capability Protocols
-///
-/// - `ScavengeCreatable`: Can start new scavenge operations
-/// - `ScavengeControllable`: Can control specific scavenge operations
-/// - `SystemControllable`: Can perform system-wide operations
-/// - `NodeControllable`: Can manage node behavior
-///
-/// - Note: This protocol is marked as `Sendable`, ensuring it can be safely used across concurrency contexts.
-///
-/// - SeeAlso: `ScavengeCreatable`, `ScavengeControllable`, `SystemControllable`, `NodeControllable`
+/// Marker protocol for types that identify the scope of a server operation.
 public protocol OperationsTarget: Sendable {}
 
-/// Extension providing a static factory method to create a `ScavengeOperations` instance.
 extension OperationsTarget where Self == ScavengeOperations {
+    /// Target for starting new scavenge operations.
     public static var scavenge: ScavengeOperations {
         .init()
     }
 }
 
-/// Extension providing a static factory method to create an `ActiveScavenge` instance.
 extension OperationsTarget where Self == ActiveScavenge {
+    /// Target for controlling the running scavenge with the given ID.
     public static func activeScavenge(scavengeId: String) -> ActiveScavenge {
         .init(scavengeId: scavengeId)
     }
 }
 
-/// Extension providing a static factory method to create a `SystemOperations` instance.
 extension OperationsTarget where Self == SystemOperations {
+    /// Target for system-wide administrative operations.
     public static var system: SystemOperations {
         .init()
     }
 }
 
-/// Extension providing a static factory method to create a `NodeOperations` instance.
 extension OperationsTarget where Self == NodeOperations {
+    /// Target for cluster node management operations.
     public static var node: NodeOperations {
         .init()
     }

--- a/Sources/KurrentDB/Operations/Protocols/NodeControllable.swift
+++ b/Sources/KurrentDB/Operations/Protocols/NodeControllable.swift
@@ -5,26 +5,5 @@
 //  Created by Grady Zhuo on 2026/2/15.
 //
 
-/// A protocol marking operation targets that support node management operations.
-///
-/// Types conforming to `NodeControllable` can manage cluster node behavior, such as
-/// resigning from leadership or adjusting node priority for election purposes.
-///
-/// ## Conforming Types
-///
-/// - `NodeOperations`: Can manage the current cluster node
-///
-/// ## Available Operations
-///
-/// Targets conforming to this protocol can:
-/// - Resign the node from its current role in the cluster
-/// - Set the node's priority for leader election
-///
-/// ## Use Cases
-///
-/// - Gracefully stepping down a leader node during maintenance
-/// - Adjusting node priorities to influence leader election
-/// - Managing cluster rebalancing and node rotation
-///
-/// - SeeAlso: `NodeOperations`
+/// Capability protocol for operation targets that support cluster node management.
 public protocol NodeControllable: OperationsTarget {}

--- a/Sources/KurrentDB/Operations/Protocols/ScavengeControllable.swift
+++ b/Sources/KurrentDB/Operations/Protocols/ScavengeControllable.swift
@@ -5,26 +5,8 @@
 //  Created by Grady Zhuo on 2026/2/15.
 //
 
-/// A protocol marking operation targets that support controlling specific scavenge operations.
-///
-/// Types conforming to `ScavengeControllable` can stop running scavenge operations
-/// identified by their scavenge ID.
-///
-/// ## Required Property
-///
-/// Conforming types must provide a `scavengeId` property that uniquely identifies the target scavenge.
-///
-/// ## Conforming Types
-///
-/// - `ActiveScavenge`: Can control a specific running scavenge operation
-///
-/// ## Available Operations
-///
-/// Targets conforming to this protocol can:
-/// - Stop the identified scavenge operation gracefully
-///
-/// - SeeAlso: `ScavengeCreatable`, `ActiveScavenge`
+/// Capability protocol for operation targets that support stopping a running scavenge.
 public protocol ScavengeControllable: OperationsTarget {
-    /// The unique identifier of the scavenge operation to control.
+    /// Unique identifier of the scavenge operation to control.
     var scavengeId: String { get }
 }

--- a/Sources/KurrentDB/Operations/Protocols/ScavengeCreatable.swift
+++ b/Sources/KurrentDB/Operations/Protocols/ScavengeCreatable.swift
@@ -5,19 +5,5 @@
 //  Created by Grady Zhuo on 2026/2/15.
 //
 
-/// A protocol marking operation targets that support starting new scavenge operations.
-///
-/// Types conforming to `ScavengeCreatable` can initiate scavenge operations to reclaim
-/// disk space by removing deleted events from database chunks.
-///
-/// ## Conforming Types
-///
-/// - `ScavengeOperations`: Can start new scavenge operations
-///
-/// ## Available Operations
-///
-/// Targets conforming to this protocol can:
-/// - Start new scavenge operations with configurable thread count and starting position
-///
-/// - SeeAlso: `ScavengeControllable`, `ScavengeOperations`
+/// Capability protocol for operation targets that support starting new scavenge operations.
 public protocol ScavengeCreatable: OperationsTarget {}

--- a/Sources/KurrentDB/Operations/Protocols/SystemControllable.swift
+++ b/Sources/KurrentDB/Operations/Protocols/SystemControllable.swift
@@ -5,27 +5,5 @@
 //  Created by Grady Zhuo on 2026/2/15.
 //
 
-/// A protocol marking operation targets that support system-wide administrative operations.
-///
-/// Types conforming to `SystemControllable` can perform cluster-wide operations that affect
-/// the entire KurrentDB system, such as shutting down the server, merging indexes, or
-/// restarting subsystems.
-///
-/// ## Conforming Types
-///
-/// - `SystemOperations`: Can perform system-wide administrative tasks
-///
-/// ## Available Operations
-///
-/// Targets conforming to this protocol can:
-/// - Shutdown the server gracefully
-/// - Merge database indexes for optimization
-/// - Restart the persistent subscriptions subsystem
-///
-/// ## Security Considerations
-///
-/// System operations require administrative privileges and can be disruptive to running services.
-/// These operations should be restricted to operators and automated management systems.
-///
-/// - SeeAlso: `SystemOperations`
+/// Capability protocol for operation targets that support system-wide administrative tasks.
 public protocol SystemControllable: OperationsTarget {}

--- a/Sources/KurrentDB/Operations/ScavengeResponse.swift
+++ b/Sources/KurrentDB/Operations/ScavengeResponse.swift
@@ -9,11 +9,17 @@ import Foundation
 import GRPCEncapsulates
 
 extension Operations {
+    /// Response returned when starting or stopping a scavenge operation.
     public struct ScavengeResponse: GRPCResponse {
+        /// Lifecycle status of a scavenge operation.
         public enum ScavengeResult: Sendable {
+            /// Scavenge has been started.
             case started
+            /// Scavenge is currently running.
             case inProgress
+            /// Scavenge has been stopped.
             case stopped
+            /// Unrecognised status value returned by the server.
             case unrecognized(Int)
         }
 

--- a/Sources/KurrentDB/Operations/Targets/ActiveScavenge.swift
+++ b/Sources/KurrentDB/Operations/Targets/ActiveScavenge.swift
@@ -5,34 +5,14 @@
 //  Created by Grady Zhuo on 2026/2/15.
 //
 
-/// A target representing a specific active scavenge operation.
-///
-/// `ActiveScavenge` is used for operations on a running scavenge, identified by its unique
-/// scavenge ID. This target type supports stopping the identified scavenge operation.
-///
-/// ## Capabilities
-///
-/// This target conforms to `ScavengeControllable`, enabling:
-/// - Stopping the specific scavenge operation gracefully
-///
-/// ## Usage
-///
-/// ```swift
-/// let activeScavenge = Operations(target: ActiveScavenge(scavengeId: "abc123"), ...)
-///
-/// // Stop the specific scavenge
-/// let response = try await activeScavenge.stopScavenge()
-/// print("Stopped scavenge: \(response.scavengeId)")
-/// ```
-///
-/// - SeeAlso: `ScavengeControllable`, `OperationsTarget`, `ScavengeOperations`
+/// Target scoped to a specific running scavenge operation, enabling it to be stopped.
 public struct ActiveScavenge: ScavengeControllable {
-    /// The unique identifier of the scavenge operation.
+    /// Unique identifier of the active scavenge operation.
     public let scavengeId: String
 
-    /// Initializes a target for a specific active scavenge.
+    /// Creates a target for the scavenge with the given ID.
     ///
-    /// - Parameter scavengeId: The unique identifier of the scavenge operation.
+    /// - Parameter scavengeId: Unique identifier of the scavenge operation.
     public init(scavengeId: String) {
         self.scavengeId = scavengeId
     }

--- a/Sources/KurrentDB/Operations/Targets/NodeOperations.swift
+++ b/Sources/KurrentDB/Operations/Targets/NodeOperations.swift
@@ -5,38 +5,7 @@
 //  Created by Grady Zhuo on 2026/2/15.
 //
 
-/// A target representing operations on the current cluster node.
-///
-/// `NodeOperations` is used for managing the behavior and role of the current node within
-/// a KurrentDB cluster, such as resigning from leadership or adjusting election priority.
-///
-/// ## Capabilities
-///
-/// This target conforms to `NodeControllable`, enabling:
-/// - Resigning the node from its current role in the cluster
-/// - Setting the node's priority for leader election
-///
-/// ## Usage
-///
-/// ```swift
-/// let node = Operations(target: NodeOperations(), ...)
-///
-/// // Resign from current role
-/// try await node.resignNode()
-///
-/// // Set node priority for elections
-/// try await node.setNodePriority(priority: 10)
-/// ```
-///
-/// ## Use Cases
-///
-/// - Gracefully stepping down a leader node during maintenance
-/// - Adjusting node priorities to influence leader election
-/// - Managing cluster rebalancing and node rotation
-/// - Preparing nodes for updates or decommissioning
-///
-/// - SeeAlso: `NodeControllable`, `OperationsTarget`
+/// Target for managing the current cluster node's role and election priority.
 public struct NodeOperations: NodeControllable {
-    /// Initializes a target for node management operations.
     public init() {}
 }

--- a/Sources/KurrentDB/Operations/Targets/ScavengeOperations.swift
+++ b/Sources/KurrentDB/Operations/Targets/ScavengeOperations.swift
@@ -5,33 +5,7 @@
 //  Created by Grady Zhuo on 2026/2/15.
 //
 
-/// A target representing scavenge operations in the KurrentDB system.
-///
-/// `ScavengeOperations` is used for starting new scavenge operations to reclaim disk space
-/// by removing deleted events from database chunks. This target type supports scavenge
-/// creation operations.
-///
-/// ## Capabilities
-///
-/// This target conforms to `ScavengeCreatable`, enabling:
-/// - Starting new scavenge operations with configurable parallelism
-/// - Specifying starting positions for resuming interrupted scavenges
-///
-/// ## Usage
-///
-/// ```swift
-/// let scavenges = Operations(target: ScavengeOperations(), ...)
-///
-/// // Start a new scavenge
-/// let response = try await scavenges.startScavenge(
-///     threadCount: 2,
-///     startFromChunk: 0
-/// )
-/// print("Started scavenge: \(response.scavengeId)")
-/// ```
-///
-/// - SeeAlso: `ScavengeCreatable`, `OperationsTarget`, `ActiveScavenge`
+/// Target for starting new scavenge operations to reclaim disk space.
 public struct ScavengeOperations: ScavengeCreatable {
-    /// Initializes a target representing scavenge operations.
     public init() {}
 }

--- a/Sources/KurrentDB/Operations/Targets/SystemOperations.swift
+++ b/Sources/KurrentDB/Operations/Targets/SystemOperations.swift
@@ -5,38 +5,7 @@
 //  Created by Grady Zhuo on 2026/2/15.
 //
 
-/// A target representing system-wide administrative operations.
-///
-/// `SystemOperations` is used for cluster-wide operations that affect the entire KurrentDB
-/// system, such as shutting down the server, merging indexes, or restarting subsystems.
-///
-/// ## Capabilities
-///
-/// This target conforms to `SystemControllable`, enabling:
-/// - Graceful server shutdown
-/// - Database index merging for optimization
-/// - Restarting the persistent subscriptions subsystem
-///
-/// ## Usage
-///
-/// ```swift
-/// let system = Operations(target: SystemOperations(), ...)
-///
-/// // Shutdown the server
-/// try await system.shutdown()
-///
-/// // Merge indexes
-/// try await system.mergeIndexes()
-///
-/// // Restart persistent subscriptions
-/// try await system.restartPersistentSubscriptions()
-/// ```
-///
-/// - Warning: System operations require administrative privileges and can be disruptive.
-///   Exercise caution when using in production environments.
-///
-/// - SeeAlso: `SystemControllable`, `OperationsTarget`
+/// Target for system-wide administrative tasks such as shutdown, index merging, and subsystem restarts.
 public struct SystemOperations: SystemControllable {
-    /// Initializes a target for system-wide operations.
     public init() {}
 }

--- a/Sources/KurrentDB/Operations/Usecase/Operations.MergeIndexes.swift
+++ b/Sources/KurrentDB/Operations/Usecase/Operations.MergeIndexes.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Operations {
+    /// Usecase that sends a merge-indexes RPC to KurrentDB.
     public struct MergeIndexes: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.MergeIndexes.Input

--- a/Sources/KurrentDB/Operations/Usecase/Operations.ResignNode.swift
+++ b/Sources/KurrentDB/Operations/Usecase/Operations.ResignNode.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Operations {
+    /// Usecase that sends a resign-node RPC to KurrentDB.
     public struct ResignNode: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.ResignNode.Input

--- a/Sources/KurrentDB/Operations/Usecase/Operations.RestartPersistentSubscriptions.swift
+++ b/Sources/KurrentDB/Operations/Usecase/Operations.RestartPersistentSubscriptions.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Operations {
+    /// Usecase that sends a restart-persistent-subscriptions RPC to KurrentDB.
     public struct RestartPersistentSubscriptions: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.RestartPersistentSubscriptions.Input

--- a/Sources/KurrentDB/Operations/Usecase/Operations.SetNodePriority.swift
+++ b/Sources/KurrentDB/Operations/Usecase/Operations.SetNodePriority.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Operations {
+    /// Usecase that sends a set-node-priority RPC to KurrentDB.
     public struct SetNodePriority: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.SetNodePriority.Input
@@ -23,6 +24,7 @@ extension Operations {
             "Operations.\(Self.self)"
         }
 
+        /// Election priority value to assign to the node.
         public let priority: Int32
 
         public init(priority: Int32) {

--- a/Sources/KurrentDB/Operations/Usecase/Operations.Shutdown.swift
+++ b/Sources/KurrentDB/Operations/Usecase/Operations.Shutdown.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Operations {
+    /// Usecase that sends a shutdown RPC to KurrentDB.
     public struct Shutdown: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.Shutdown.Input

--- a/Sources/KurrentDB/Operations/Usecase/Operations.StartScavenge.swift
+++ b/Sources/KurrentDB/Operations/Usecase/Operations.StartScavenge.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Operations {
+    /// Usecase that sends a start-scavenge RPC to KurrentDB.
     public struct StartScavenge: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.StartScavenge.Input
@@ -23,7 +24,9 @@ extension Operations {
             "Operations.\(Self.self)"
         }
 
+        /// Number of parallel threads to use during scavenging.
         public let threadCount: Int32
+        /// Chunk index from which to begin scavenging.
         public let startFromChunk: Int32
 
         public init(threadCount: Int32, startFromChunk: Int32) {

--- a/Sources/KurrentDB/Operations/Usecase/Operations.StopScavenge.swift
+++ b/Sources/KurrentDB/Operations/Usecase/Operations.StopScavenge.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Operations {
+    /// Usecase that sends a stop-scavenge RPC to KurrentDB.
     public struct StopScavenge: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.StopScavenge.Input

--- a/Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+All.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+All.swift
@@ -7,15 +7,18 @@
 
 extension PersistentSubscriptions where Target == AllPersistentSubscriptionTarget {
 
+    /// Lists all persistent subscriptions on the server.
+    ///
+    /// - Returns: An array of `SubscriptionInfo` describing every persistent subscription.
+    /// - Throws: `KurrentError` if the request fails.
     public func list() async throws(KurrentError) -> [PersistentSubscription.SubscriptionInfo] {
         let usecase = ListForAll(filter: .stream(.all))
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Restarts the subsystem managing persistent subscriptions.
+    /// Restarts the persistent subscriptions subsystem on the server.
     ///
-    /// This operation reinitializes the persistent subscription infrastructure on the server side.
-    /// Throws a `KurrentError` if the restart fails.
+    /// - Throws: `KurrentError` if the restart request fails.
     @MainActor
     public func restartSubsystem() async throws(KurrentError) {
         let usecase = RestartSubsystem()

--- a/Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+AllStream.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+AllStream.swift
@@ -6,15 +6,14 @@
 // MARK: - All Stream Operations
 
 extension PersistentSubscriptions where Target == AllStreamPersistentSubscriptionTarget {
-    /// The group name of the persistent subscription.
+    /// Consumer group name for this `$all`-stream subscription.
     public var group: String {
         target.group
     }
 
-    /// Creates a persistent subscription for all streams with the specified options.
+    /// Creates a persistent subscription on the `$all` stream.
     ///
-    /// - Parameter options: Configuration options for creating the persistent subscription. Defaults to the standard options.
-    ///
+    /// - Parameter configure: Closure that customizes creation options before the request is sent.
     /// - Throws: `KurrentError` if the subscription could not be created.
     public func create(configure: @Sendable (inout AllStream.Create.Options) -> Void = { _ in }) async throws(KurrentError) {
         var options = AllStream.Create.Options()
@@ -23,9 +22,9 @@ extension PersistentSubscriptions where Target == AllStreamPersistentSubscriptio
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Updates the persistent subscription for all streams with the specified options.
+    /// Updates the persistent subscription on the `$all` stream.
     ///
-    /// - Parameter configure: A closure to configure update options. Defaults to no-op.
+    /// - Parameter configure: Closure that customizes update options before the request is sent.
     /// - Throws: `KurrentError` if the update operation fails.
     public func update(configure: @Sendable (inout AllStream.Update.Options) -> Void = { _ in }) async throws(KurrentError) {
         var options = AllStream.Update.Options()
@@ -34,7 +33,7 @@ extension PersistentSubscriptions where Target == AllStreamPersistentSubscriptio
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Deletes the persistent subscription group for all streams.
+    /// Deletes the persistent subscription group from the `$all` stream.
     ///
     /// - Throws: `KurrentError` if the deletion fails.
     public func delete() async throws(KurrentError) {
@@ -42,19 +41,19 @@ extension PersistentSubscriptions where Target == AllStreamPersistentSubscriptio
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Retrieves information about the persistent subscription group for all streams.
+    /// Retrieves current statistics and configuration for the `$all`-stream subscription group.
     ///
-    /// - Returns: Details of the persistent subscription group.
-    /// - Throws: `KurrentError` if the operation fails.
+    /// - Returns: A `SubscriptionInfo` snapshot for this subscription group.
+    /// - Throws: `KurrentError` if the request fails.
     public func getInfo() async throws(KurrentError) -> PersistentSubscription.SubscriptionInfo {
         let usecase = AllStream.GetInfo(group: group)
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Subscribes to a persistent subscription for all streams using the specified options.
+    /// Opens a persistent subscription on the `$all` stream and returns an active handle.
     ///
-    /// - Parameter configure: Configuration options for the subscription. Defaults to no-op.
-    /// - Returns: A `Subscription` instance representing the active persistent subscription.
+    /// - Parameter configure: Closure that customizes read options before the connection is opened.
+    /// - Returns: A `Subscription` handle for receiving and acknowledging events.
     /// - Throws: `KurrentError` if the subscription could not be established.
     public func subscribe(configure: @Sendable (inout AllStream.Read.Options) -> Void = { _ in }) async throws(KurrentError) -> Subscription<PersistentSubscription.EventResult> {
         var options = AllStream.Read.Options()
@@ -63,10 +62,10 @@ extension PersistentSubscriptions where Target == AllStreamPersistentSubscriptio
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Replays parked messages for the persistent subscription group across all streams.
+    /// Replays all parked messages for this `$all`-stream subscription group.
     ///
-    /// - Parameter configure: A closure to configure replay options. Defaults to no-op.
-    /// - Throws: `KurrentError` if the operation fails.
+    /// - Parameter configure: Closure that customizes replay options before the request is sent.
+    /// - Throws: `KurrentError` if the replay request fails.
     public func replayParked(configure: @Sendable (inout AllStream.ReplayParked.Options) -> Void = { _ in }) async throws(KurrentError) {
         var options = AllStream.ReplayParked.Options()
         configure(&options)

--- a/Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+FilterStream.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+FilterStream.swift
@@ -6,6 +6,10 @@
 // MARK: - FilterStream Operations
 
 extension PersistentSubscriptions where Target == FilterStreamPersistentSubscriptionTarget {
+    /// Lists all persistent subscriptions for the filtered stream.
+    ///
+    /// - Returns: An array of `SubscriptionInfo` for subscriptions on the target stream.
+    /// - Throws: `KurrentError` if the request fails.
     public func list() async throws(KurrentError) -> [PersistentSubscription.SubscriptionInfo] {
         let usecase = ListForAll(filter: .stream(target.stream))
         return try await usecase.perform(selector: selector, callOptions: callOptions)

--- a/Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+Specified.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+Specified.swift
@@ -6,14 +6,14 @@
 // MARK: - Specified Stream Operations
 
 extension PersistentSubscriptions where Target == SpecifiedPersistentSubscriptionTarget {
-    /// The group name of the persistent subscription.
+    /// Consumer group name for this named-stream subscription.
     public var group: String {
         target.group
     }
 
-    /// Creates a persistent subscription for a specified stream with the given options.
+    /// Creates a persistent subscription on the target stream.
     ///
-    /// - Parameter configure: A closure to configure creation options. Defaults to no-op.
+    /// - Parameter configure: Closure that customizes creation options before the request is sent.
     /// - Throws: `KurrentError` if the subscription could not be created.
     public func create(configure: @Sendable (inout SpecifiedStream.Create.Options) -> Void = { _ in }) async throws(KurrentError) {
         var options = SpecifiedStream.Create.Options()
@@ -22,9 +22,9 @@ extension PersistentSubscriptions where Target == SpecifiedPersistentSubscriptio
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Updates the persistent subscription for the specified stream with the provided options.
+    /// Updates the persistent subscription on the target stream.
     ///
-    /// - Parameter configure: A closure to configure update options. Defaults to no-op.
+    /// - Parameter configure: Closure that customizes update options before the request is sent.
     /// - Throws: `KurrentError` if the update operation fails.
     public func update(configure: @Sendable (inout SpecifiedStream.Update.Options) -> Void = { _ in }) async throws(KurrentError) {
         var options = SpecifiedStream.Update.Options()
@@ -35,7 +35,7 @@ extension PersistentSubscriptions where Target == SpecifiedPersistentSubscriptio
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Deletes the persistent subscription for the specified stream and group.
+    /// Deletes the persistent subscription from the target stream.
     ///
     /// - Throws: `KurrentError` if the deletion fails.
     public func delete() async throws(KurrentError) {
@@ -43,19 +43,29 @@ extension PersistentSubscriptions where Target == SpecifiedPersistentSubscriptio
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Retrieves information about the persistent subscription for the specified stream and group.
+    /// Retrieves current statistics and configuration for the named-stream subscription group.
     ///
-    /// - Returns: Subscription information for the targeted stream and group.
-    /// - Throws: `KurrentError` if the operation fails.
+    /// - Returns: A `SubscriptionInfo` snapshot for this subscription group.
+    /// - Throws: `KurrentError` if the request fails.
     public func getInfo() async throws(KurrentError) -> PersistentSubscription.SubscriptionInfo {
         let usecase = SpecifiedStream.GetInfo(stream: target.identifier, group: group)
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Subscribes to a persistent subscription on a specified stream.
+    /// Opens a persistent subscription on the target stream and returns an active handle.
     ///
-    /// - Parameter configure: A closure to configure subscription options. Defaults to no-op.
-    /// - Returns: A `Subscription` representing the active persistent subscription.
+    /// ```swift
+    /// let sub = client.persistentSubscriptions(stream: "orders", group: "processors")
+    /// try await sub.create()
+    /// let subscription = try await sub.subscribe()
+    /// for try await result in subscription.events {
+    ///     print(result.event.record.eventType)
+    ///     try await subscription.ack(readEvents: result.event)
+    /// }
+    /// ```
+    ///
+    /// - Parameter configure: Closure that customizes read options before the connection is opened.
+    /// - Returns: A `Subscription` handle for receiving and acknowledging events.
     /// - Throws: `KurrentError` if the subscription could not be established.
     public func subscribe(configure: @Sendable (inout SpecifiedStream.Read.Options) -> Void = { _ in }) async throws(KurrentError) -> Subscription<PersistentSubscription.EventResult> {
         var options = SpecifiedStream.Read.Options()
@@ -64,10 +74,10 @@ extension PersistentSubscriptions where Target == SpecifiedPersistentSubscriptio
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Replays parked messages for the specified persistent subscription stream.
+    /// Replays all parked messages for this named-stream subscription group.
     ///
-    /// - Parameter configure: A closure to configure replay options. Defaults to no-op.
-    /// - Throws: `KurrentError` if the replay operation fails.
+    /// - Parameter configure: Closure that customizes replay options before the request is sent.
+    /// - Throws: `KurrentError` if the replay request fails.
     public func replayParked(configure: @Sendable (inout SpecifiedStream.ReplayParked.Options) -> Void = { _ in }) async throws(KurrentError) {
         var options = SpecifiedStream.ReplayParked.Options()
         configure(&options)

--- a/Sources/KurrentDB/PersistentSubscriptions/KurrentDBClient+PersistentSubscriptions.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/KurrentDBClient+PersistentSubscriptions.swift
@@ -8,48 +8,43 @@
 // MARK: - Persistent Subscription Factory Methods
 
 extension KurrentDBClient {
-    /// Accesses persistent subscriptions for cluster-wide operations (list, restart subsystem).
+    /// Provides access to cluster-wide persistent subscription operations such as listing all subscriptions.
     ///
-    /// ```swift
-    /// let allSubs = try await client.allPersistentSubscriptions.list()
-    /// ```
+    /// - Returns: A `PersistentSubscriptions` instance scoped to all subscriptions.
     public var allPersistentSubscriptions: PersistentSubscriptions<AllPersistentSubscriptionTarget> {
         .init(target: .all, selector: selector, callOptions: defaultCallOptions)
     }
 
-    /// Creates a persistent subscriptions interface for a specific target type.
+    /// Returns a `PersistentSubscriptions` instance scoped to the given target.
     ///
-    /// - Parameter target: The subscription target defining the scope.
-    /// - Returns: A configured ``PersistentSubscriptions`` instance.
+    /// - Parameter target: The target that defines the subscription scope.
+    /// - Returns: A `PersistentSubscriptions` instance for the specified target.
     public func persistentSubscriptions<Target: PersistentSubscriptionTarget>(of target: Target) -> PersistentSubscriptions<Target> {
         .init(target: target, selector: selector, callOptions: defaultCallOptions)
     }
 
-    /// Creates a persistent subscriptions interface for a specific stream and consumer group.
-    ///
-    /// ```swift
-    /// let sub = client.persistentSubscriptions(stream: "orders", group: "order-processor")
-    /// try await sub.create()
-    /// let subscription = try await sub.subscribe()
-    /// ```
+    /// Returns a `PersistentSubscriptions` instance scoped to a specific stream and consumer group.
     ///
     /// - Parameters:
-    ///   - stream: The stream name to subscribe to.
-    ///   - group: The consumer group name.
+    ///   - stream: Name of the stream to subscribe to.
+    ///   - group: Consumer group name for the subscription.
+    /// - Returns: A `PersistentSubscriptions` instance for the named stream and group.
     public func persistentSubscriptions(stream: String, group: String) -> PersistentSubscriptions<SpecifiedPersistentSubscriptionTarget> {
         .init(target: .specified(stream: stream, group: group), selector: selector, callOptions: defaultCallOptions)
     }
 
-    /// Lists persistent subscriptions filtered by consumer group name across all streams.
+    /// Returns a `PersistentSubscriptions` instance that lists subscriptions for the given consumer group on all streams.
     ///
-    /// - Parameter groupName: The consumer group name to filter by.
+    /// - Parameter groupName: Consumer group name to filter by.
+    /// - Returns: A `PersistentSubscriptions` instance scoped to the `$all`-stream group.
     public func persistentSubscriptions(filterGroup groupName: String) -> PersistentSubscriptions<AllStreamPersistentSubscriptionTarget> {
         .init(target: .allStreams(group: groupName), selector: selector, callOptions: defaultCallOptions)
     }
 
-    /// Lists persistent subscriptions filtered by stream name.
+    /// Returns a `PersistentSubscriptions` instance that lists subscriptions filtered to a specific stream.
     ///
-    /// - Parameter stream: The stream name to filter by.
+    /// - Parameter stream: Stream name to filter by.
+    /// - Returns: A `PersistentSubscriptions` instance scoped to the given stream filter.
     public func persistentSubscriptions(filterStream stream: String) -> PersistentSubscriptions<FilterStreamPersistentSubscriptionTarget> {
         .init(target: .filter(stream: stream), selector: selector, callOptions: defaultCallOptions)
     }

--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptionStreamSelection.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptionStreamSelection.swift
@@ -8,25 +8,31 @@
 import GRPCEncapsulates
 import SwiftProtobuf
 
+/// Identifies the stream that a persistent subscription targets.
 public protocol PersistentSubscriptionStreamSelection: Sendable {
     associatedtype Cursor: Sendable
+    /// Identifier of the target stream.
     var streamIdentifier: StreamIdentifier { get }
 }
 
 extension PersistentSubscriptionStreamSelection where Self == PersistentSubscriptionSpecifiedStream {
+    /// Creates a selection targeting a specific named stream.
     public static func specified(_ streamIdentifier: StreamIdentifier) -> Self {
         .init(streamIdentifier: streamIdentifier)
     }
 }
 
 extension PersistentSubscriptionStreamSelection where Self == PersistentSubscriptionStreamAll {
+    /// Creates a selection targeting the global `$all` stream.
     public static var all: Self {
         .init()
     }
 }
 
+/// A stream selection that targets a specific named stream.
 public struct PersistentSubscriptionSpecifiedStream: PersistentSubscriptionStreamSelection {
     public typealias Cursor = RevisionCursor
+    /// Identifier of the named stream.
     public let streamIdentifier: StreamIdentifier
 
     package init(streamIdentifier: StreamIdentifier) {
@@ -34,8 +40,10 @@ public struct PersistentSubscriptionSpecifiedStream: PersistentSubscriptionStrea
     }
 }
 
+/// A stream selection that targets the global `$all` stream.
 public struct PersistentSubscriptionStreamAll: PersistentSubscriptionStreamSelection {
     public typealias Cursor = PositionCursor
+    /// Always returns the well-known `$all` stream identifier.
     public var streamIdentifier: StreamIdentifier {
         .all
     }

--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.ReadResponse.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.ReadResponse.swift
@@ -8,10 +8,13 @@
 import GRPCEncapsulates
 
 extension PersistentSubscriptions {
+    /// Server response received on the persistent subscription read stream.
     public enum ReadResponse: GRPCResponse {
         package typealias UnderlyingMessage = PersistentSubscriptions.UnderlyingService.Method.Read.Output
 
+        /// An event delivered by the subscription along with its retry count.
         case readEvent(event: ReadEvent, retryCount: Int32)
+        /// Initial handshake message confirming the subscription identifier.
         case confirmation(subscriptionId: String)
 
         package init(from message: UnderlyingMessage) throws {

--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.StreamSelection.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.StreamSelection.swift
@@ -6,8 +6,11 @@
 //
 
 extension PersistentSubscriptions {
+    /// Defines which stream a persistent subscription reads from and where it starts.
     public enum StreamSelection: Sendable {
+        /// Reads from a specific named stream starting at the given revision cursor.
         case specified(identifier: StreamIdentifier, cursor: RevisionCursor)
+        /// Reads from the global `$all` stream starting at the given position cursor.
         case all(cursor: PositionCursor)
     }
 }

--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift
@@ -13,6 +13,22 @@ import GRPCNIOTransportHTTP2Posix
 import Synchronization
 
 extension PersistentSubscriptions {
+    /// An active handle to a persistent subscription session.
+    ///
+    /// Obtain an instance through ``PersistentSubscriptions/subscribe(configure:)``.
+    /// Iterate ``events`` to receive delivered events, then call ``ack(readEvents:)``
+    /// or ``nack(readEvents:action:reason:)`` for each one.
+    ///
+    /// Breaking out of the `for try await` loop — or letting the subscription go out of
+    /// scope — automatically stops the underlying gRPC stream and closes the server-side
+    /// connection.
+    ///
+    /// ```swift
+    /// let subscription = try await ps.subscribe()
+    /// for try await result in subscription.events {
+    ///     try await subscription.ack(readEvents: result.event)
+    /// }
+    /// ```
     public final class Subscription<EventResult: SubscriptionEventResult>: Sendable {
         package typealias Request = PersistentSubscriptions.UnderlyingService.Method.Read.Input
 
@@ -21,18 +37,35 @@ extension PersistentSubscriptions {
         private let writer: Writer
         private let _eventsCache: Mutex<AsyncThrowingStream<EventResult, Error>?> = .init(nil)
 
+        /// Server-assigned identifier for this subscription session.
         public var subscriptionId: String? {
             tracker.subscriptionId
         }
 
+        /// Stream revision of the most recently received event, or `nil` before any event arrives.
+        ///
+        /// Use this value to resume a subscription from a known position after a drop.
         public var lastRevision: UInt64? {
             tracker.revision
         }
 
+        /// Global log position of the most recently received event in the `$all` stream,
+        /// or `nil` before any event arrives.
+        ///
+        /// Use this value when subscribing to `$all` to resume from a known position after a drop.
         public var lastPosition: StreamPosition? {
             tracker.position
         }
 
+        /// Asynchronous stream of events delivered by this subscription.
+        ///
+        /// The stream is created lazily on first access and cached — every subsequent access
+        /// returns the same instance.  This ensures that exactly one iterator consumes the
+        /// underlying gRPC response stream at any given time.
+        ///
+        /// Breaking out of the `for try await` loop cancels the bridge task, stops the gRPC
+        /// write stream, and closes the server-side connection.  After cancellation, further
+        /// iteration of the same stream returns immediately without yielding new events.
         public var events: AsyncThrowingStream<EventResult, Error> {
             _eventsCache.withLock { cache in
                 if let existing = cache {
@@ -105,6 +138,10 @@ extension PersistentSubscriptions {
             }
         }
 
+        /// Acknowledges an array of events, signalling successful processing to the server.
+        ///
+        /// - Parameter readEvents: Events to acknowledge.
+        /// - Throws: `KurrentError` if the acknowledgement request cannot be sent.
         public func ack(readEvents: [ReadEvent]) async throws(KurrentError) {
             let eventIds = readEvents.map {
                 if let link = $0.link { link.id } else { $0.record.id }
@@ -112,6 +149,10 @@ extension PersistentSubscriptions {
             try await ack(eventIds: eventIds)
         }
 
+        /// Acknowledges one or more events passed as variadic arguments.
+        ///
+        /// - Parameter readEvents: Events to acknowledge.
+        /// - Throws: `KurrentError` if the acknowledgement request cannot be sent.
         public func ack(readEvents: ReadEvent ...) async throws(KurrentError) {
             try await ack(readEvents: readEvents)
         }
@@ -126,6 +167,13 @@ extension PersistentSubscriptions {
             }
         }
 
+        /// Negatively acknowledges an array of events, instructing the server to apply the specified action.
+        ///
+        /// - Parameters:
+        ///   - readEvents: Events to negatively acknowledge.
+        ///   - action: Retry or discard action the server should apply to these events.
+        ///   - reason: Human-readable explanation for the negative acknowledgement.
+        /// - Throws: `KurrentError` if the nack request cannot be sent.
         public func nack(readEvents: [ReadEvent], action: PersistentSubscriptions.Nack.Action, reason: String) async throws(KurrentError) {
             let eventIds = readEvents.map {
                 if let link = $0.link { link.id } else { $0.record.id }
@@ -133,6 +181,13 @@ extension PersistentSubscriptions {
             try await nack(eventIds: eventIds, action: action, reason: reason)
         }
 
+        /// Negatively acknowledges one or more events passed as variadic arguments.
+        ///
+        /// - Parameters:
+        ///   - readEvents: Events to negatively acknowledge.
+        ///   - action: Retry or discard action the server should apply to these events.
+        ///   - reason: Human-readable explanation for the negative acknowledgement.
+        /// - Throws: `KurrentError` if the nack request cannot be sent.
         public func nack(readEvents: ReadEvent ..., action: PersistentSubscriptions.Nack.Action, reason: String) async throws(KurrentError) {
             try await nack(readEvents: readEvents, action: action, reason: reason)
         }

--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift
@@ -76,9 +76,15 @@ extension PersistentSubscriptions {
 
                 let task = Task {
                     do {
-                        for try await subscriptionResult in source.stream {
-                            let result = continuation.yield(subscriptionResult)
-                            if case .terminated = result {
+                        for try await eventResult in source.stream {
+                            let yieldResult = continuation.yield(eventResult)
+                            if let revision = eventResult.revision{
+                                tracker.update(revision: revision)
+                            }
+                            if let position = eventResult.position {
+                                tracker.update(position: position)
+                            }
+                            if case .terminated = yieldResult {
                                 continuation.finish()
                                 return
                             }
@@ -112,9 +118,6 @@ extension PersistentSubscriptions {
             case let .confirmation(subscriptionId):
                 tracker.update(subscriptionId: subscriptionId)
             case let .response(eventResult):
-                if let revision = eventResult.revision, let position = eventResult.position {
-                    tracker.update(revision: revision, position: position)
-                }
                 let result = source.continuation.yield(eventResult)
                 if case .terminated = result {
                     source.continuation.finish()
@@ -260,8 +263,11 @@ extension PersistentSubscriptions.Subscription {
             _finishAction.withLock { $0 = action }
         }
 
-        func update(revision: UInt64, position: StreamPosition) {
+        func update(revision: UInt64) {
             _revision.withLock { $0 = revision }
+        }
+        
+        func update(position: StreamPosition) {
             _position.withLock { $0 = position }
         }
 

--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.swift
@@ -12,32 +12,18 @@ import GRPCNIOTransportHTTP2Posix
 import Logging
 import NIO
 
+/// Service facade for persistent subscription operations scoped to a specific target.
 public final class PersistentSubscriptions<Target: PersistentSubscriptionTarget>: GRPCConcreteService {
-    /// The underlying gRPC service type.
     package typealias UnderlyingService = EventStore_Client_PersistentSubscriptions_PersistentSubscriptions
-
-    /// The underlying client type used for gRPC communication.
     package typealias UnderlyingClient = UnderlyingService.Client<HTTP2ClientTransport.Posix>
 
-    /// The settings used for client communication.
     internal let selector: NodeSelector
-
-    /// Options to be used for each gRPC service call.
     internal let callOptions: CallOptions
-
-    /// The event loop group for asynchronous execution.
     internal let eventLoopGroup: EventLoopGroup
 
-    /// The target stream for the subscription (e.g., specific stream, all streams, or generic).
+    /// Target that defines which stream or scope this service instance operates on.
     public let target: Target
 
-    /// Initializes a `PersistentSubscriptions` instance.
-    ///
-    /// - Parameters:
-    ///   - target: The target stream for the subscription (e.g., `Specified`, `All`, or `AnyTarget`).
-    ///   - settings: The settings used for client communication.
-    ///   - callOptions: Options for the gRPC call, defaulting to `.defaults`.
-    ///   - eventLoopGroup: The event loop group for async operations, defaulting to `.singletonMultiThreadedEventLoopGroup`.
     init(target: Target, selector: NodeSelector, callOptions: CallOptions = .defaults, eventLoopGroup: EventLoopGroup = .singletonMultiThreadedEventLoopGroup) {
         self.selector = selector
         self.callOptions = callOptions
@@ -47,17 +33,19 @@ public final class PersistentSubscriptions<Target: PersistentSubscriptionTarget>
 }
 
 extension PersistentSubscriptions {
+    /// Namespace for persistent subscription operations on a specific named stream.
     public struct SpecifiedStream {}
+    /// Namespace for persistent subscription operations on the `$all` stream.
     public struct AllStream {}
 }
 
 // MARK: - Streams
 
 extension Streams where Target: SpecifiedStreamTarget {
-    /// Returns a `PersistentSubscriptions` instance for a specified stream and subscription group.
+    /// Returns a `PersistentSubscriptions` scoped to this stream and the given consumer group.
     ///
-    /// - Parameter group: The name of the persistent subscription group.
-    /// - Returns: A `PersistentSubscriptions` actor scoped to the given stream identifier and group.
+    /// - Parameter group: Consumer group name.
+    /// - Returns: A `PersistentSubscriptions` instance for the specified stream and group.
     public func persistentSubscriptions(group: String) -> PersistentSubscriptions<SpecifiedPersistentSubscriptionTarget> {
         let target = SpecifiedPersistentSubscriptionTarget(identifier: target.identifier, group: group)
         return .init(target: target, selector: selector, callOptions: callOptions)
@@ -65,6 +53,10 @@ extension Streams where Target: SpecifiedStreamTarget {
 }
 
 extension Streams where Target == AllStreamsTarget {
+    /// Returns a `PersistentSubscriptions` scoped to the `$all` stream and the given consumer group.
+    ///
+    /// - Parameter group: Consumer group name.
+    /// - Returns: A `PersistentSubscriptions` instance for the `$all` stream and group.
     public func persistentSubscriptions(group: String) -> PersistentSubscriptions<AllStreamPersistentSubscriptionTarget> {
         let target = AllStreamPersistentSubscriptionTarget(group: group)
         return .init(target: target, selector: selector, callOptions: callOptions)

--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptionsSettingsBuildable.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptionsSettingsBuildable.swift
@@ -8,7 +8,9 @@
 import Foundation
 import GRPCEncapsulates
 
+/// Protocol for option types that carry configurable persistent subscription settings.
 public protocol PersistentSubscriptionsSettingsBuildable: Buildable {
     associatedtype SettingsType
+    /// Mutable settings that configure the persistent subscription operation.
     var settings: SettingsType { set get }
 }

--- a/Sources/KurrentDB/PersistentSubscriptions/SubscriptionEventResult.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/SubscriptionEventResult.swift
@@ -6,7 +6,16 @@
 //
 
 
+/// A type that carries the stream position metadata required by a generic ``PersistentSubscriptions/Subscription``.
+///
+/// Conform your custom event-result type to this protocol when you specialise
+/// `Subscription<EventResult>` with a type other than the built-in
+/// `PersistentSubscription.EventResult`.  The subscription uses `revision` and
+/// `position` to track the last successfully received event so that callers can
+/// resume after a drop.
 public protocol SubscriptionEventResult: Sendable {
+    /// Stream revision of the event, or `nil` if the event has no revision (e.g. system events).
     var revision: UInt64? { get }
+    /// Global log position of the event in the `$all` stream, or `nil` if unavailable.
     var position: StreamPosition? { get }
 }

--- a/Sources/KurrentDB/PersistentSubscriptions/Target/AllPersistentSubscriptionTarget.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Target/AllPersistentSubscriptionTarget.swift
@@ -3,11 +3,11 @@
 //  KurrentDB
 //
 
-/// A target for cluster-wide persistent subscription operations (list all, restart subsystem).
+/// Target for cluster-wide persistent subscription operations such as listing all subscriptions.
 public struct AllPersistentSubscriptionTarget: PersistentSubscriptionTarget {}
 
 extension PersistentSubscriptionTarget where Self == AllPersistentSubscriptionTarget {
-    /// Returns the target representing all persistent subscriptions across the cluster.
+    /// Target representing all persistent subscriptions across the cluster.
     public static var all: AllPersistentSubscriptionTarget {
         .init()
     }

--- a/Sources/KurrentDB/PersistentSubscriptions/Target/AllStreamPersistentSubscriptionTarget.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Target/AllStreamPersistentSubscriptionTarget.swift
@@ -3,9 +3,9 @@
 //  KurrentDB
 //
 
-/// A target that identifies a persistent subscription on the `$all` stream.
+/// Target scoping a persistent subscription to the `$all` stream.
 public struct AllStreamPersistentSubscriptionTarget: PersistentSubscriptionTarget {
-    /// The subscription group name.
+    /// Consumer group name for this subscription.
     public private(set) var group: String
 
     public init(group: String) {
@@ -14,7 +14,7 @@ public struct AllStreamPersistentSubscriptionTarget: PersistentSubscriptionTarge
 }
 
 extension PersistentSubscriptionTarget where Self == AllStreamPersistentSubscriptionTarget {
-    /// Creates a target for the `$all` stream and subscription group.
+    /// Creates a target for the `$all` stream and the given consumer group.
     public static func allStreams(group: String) -> AllStreamPersistentSubscriptionTarget {
         .init(group: group)
     }

--- a/Sources/KurrentDB/PersistentSubscriptions/Target/AnyPersistentSubscriptionTarget.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Target/AnyPersistentSubscriptionTarget.swift
@@ -3,5 +3,5 @@
 //  KurrentDB
 //
 
-/// A generic subscription target used in contexts where the specific type is not required.
+/// Type-erased target for use when the specific subscription scope is not needed.
 public struct AnyPersistentSubscriptionTarget: PersistentSubscriptionTarget {}

--- a/Sources/KurrentDB/PersistentSubscriptions/Target/FilterStreamPersistentSubscriptionTarget.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Target/FilterStreamPersistentSubscriptionTarget.swift
@@ -3,7 +3,7 @@
 //  KurrentDB
 //
 
-/// A target used to list or filter subscriptions by stream name.
+/// Target that filters persistent subscription listings to a specific stream name.
 public struct FilterStreamPersistentSubscriptionTarget: PersistentSubscriptionTarget {
     let stream: String
 
@@ -13,7 +13,7 @@ public struct FilterStreamPersistentSubscriptionTarget: PersistentSubscriptionTa
 }
 
 extension PersistentSubscriptionTarget where Self == FilterStreamPersistentSubscriptionTarget {
-    /// Creates a filter target scoped to a specific stream name.
+    /// Creates a target that filters subscription listings to the given stream name.
     public static func filter(stream: String) -> FilterStreamPersistentSubscriptionTarget {
         .init(stream: stream)
     }

--- a/Sources/KurrentDB/PersistentSubscriptions/Target/PersistentSubscriptionTarget.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Target/PersistentSubscriptionTarget.swift
@@ -3,29 +3,5 @@
 //  KurrentDB
 //
 
-/// Represents a target for persistent subscriptions.
-///
-/// Conform to this protocol to define a subscription scope.
-/// Use the static factory methods on the protocol extensions to create targets:
-///
-/// ```swift
-/// // Specific stream
-/// let target = SpecifiedPersistentSubscriptionTarget.specified(stream: "orders", group: "workers")
-///
-/// // All streams
-/// let allTarget = AllStreamPersistentSubscriptionTarget.allStreams(group: "workers")
-///
-/// // Cluster-wide operations
-/// let clusterTarget = AllPersistentSubscriptionTarget.all
-/// ```
-///
-/// - Note: This protocol is marked as `Sendable`.
-///
-/// ### Topics
-/// #### Conforming Types
-/// - ``SpecifiedPersistentSubscriptionTarget``
-/// - ``AllStreamPersistentSubscriptionTarget``
-/// - ``FilterStreamPersistentSubscriptionTarget``
-/// - ``AllPersistentSubscriptionTarget``
-/// - ``AnyPersistentSubscriptionTarget``
+/// Defines the scope of a persistent subscription operation.
 public protocol PersistentSubscriptionTarget: Sendable {}

--- a/Sources/KurrentDB/PersistentSubscriptions/Target/SpecifiedPersistentSubscriptionTarget.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Target/SpecifiedPersistentSubscriptionTarget.swift
@@ -5,12 +5,12 @@
 
 import Foundation
 
-/// A target that identifies a persistent subscription on a specific named stream.
+/// Target scoping a persistent subscription to a specific named stream.
 public struct SpecifiedPersistentSubscriptionTarget: PersistentSubscriptionTarget {
-    /// The identifier of the stream.
+    /// Identifier of the stream this subscription reads from.
     public private(set) var identifier: StreamIdentifier
 
-    /// The subscription group name.
+    /// Consumer group name for this subscription.
     public private(set) var group: String
 
     public init(identifier: StreamIdentifier, group: String) {
@@ -20,7 +20,7 @@ public struct SpecifiedPersistentSubscriptionTarget: PersistentSubscriptionTarge
 }
 
 extension PersistentSubscriptionTarget where Self == SpecifiedPersistentSubscriptionTarget {
-    /// Creates a target for a named stream and subscription group.
+    /// Creates a target for the named stream and consumer group.
     public static func specified(stream name: String, encoding: String.Encoding = .utf8, group: String) -> SpecifiedPersistentSubscriptionTarget {
         .init(identifier: .init(name: name, encoding: encoding), group: group)
     }

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.Create.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.Create.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.AllStream {
+    /// Usecase for creating a persistent subscription on the `$all` stream.
     public struct Create: UnaryUnary {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.Create.Input
@@ -31,11 +32,6 @@ extension PersistentSubscriptions.AllStream {
             self.options = options
         }
 
-        /// Constructs the underlying gRPC request message for creating a persistent subscription.
-        ///
-        /// Builds the request based on the selected stream(s), group name, and subscription options, including cursor position and optional filters.
-        ///
-        /// - Returns: The constructed gRPC request message.
         /// Constructs the gRPC request message for creating a persistent subscription to all streams.
         ///
         /// - Throws: An error if building the subscription options fails.
@@ -58,11 +54,15 @@ extension PersistentSubscriptions.AllStream {
 }
 
 extension PersistentSubscriptions.AllStream.Create {
+    /// Configuration options for creating a persistent subscription on the `$all` stream.
     public struct Options: CommandOptions, PersistentSubscriptionsSettingsBuildable {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// The subscription creation settings such as consumer strategy, timeouts, and retry behaviour.
         public var settings: PersistentSubscription.CreateSettings
+        /// An optional filter to restrict which events are delivered to the subscription.
         public var filter: SubscriptionFilter?
+        /// The starting position in the `$all` stream from which events will be delivered.
         public var position: PositionCursor
 
         public init() {
@@ -75,7 +75,7 @@ extension PersistentSubscriptions.AllStream.Create {
         ///
         /// Configures the subscription settings, optional filter, and starting position within the stream.
         ///
-        /// - Returns: The constructed gRPC request message for creating the persistent subscription.
+        /// - Returns: The gRPC options message for the create request.
         package func build() -> UnderlyingMessage {
             .with {
                 $0.settings = .make(settings: settings)

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.Delete.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.Delete.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.AllStream {
+    /// Usecase for deleting a persistent subscription group on the `$all` stream.
     public struct Delete: UnaryUnary {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.Delete.Input

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.GetInfo.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.GetInfo.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.AllStream {
+    /// Usecase for retrieving information about a persistent subscription group on the `$all` stream.
     public struct GetInfo: UnaryUnary {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.GetInfo.Input

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.List.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.List.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.AllStream {
+    /// Usecase for listing all persistent subscriptions across all streams.
     public struct List: UnaryUnary {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.List.Input

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.Read.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.Read.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.AllStream {
+    /// Usecase for reading events from a persistent subscription on the `$all` stream.
     public struct Read: StreamStream {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.Read.Input
@@ -24,8 +25,11 @@ extension PersistentSubscriptions.AllStream {
             "PersistentSubscriptions.\(Self.self)"
         }
 
+        /// The stream identifier, always `nil` for the `$all` stream.
         public let streamIdentifier: StreamIdentifier?
+        /// The consumer group name for the persistent subscription.
         public let group: String
+        /// The read options for this subscription request.
         public let options: Options
 
         init(group: String, options: Options) {
@@ -97,10 +101,13 @@ extension PersistentSubscriptions.AllStream {
 }
 
 extension PersistentSubscriptions.AllStream.Read {
+    /// Configuration options for reading from a persistent subscription on the `$all` stream.
     public struct Options: CommandOptions {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// The maximum number of messages to buffer before applying back-pressure.
         public var bufferSize: Int32
+        /// The UUID representation format used for event identifiers in the response.
         public var uuidOption: UUID.Option
 
         public init() {

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.ReplayParked.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.ReplayParked.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.AllStream {
+    /// Usecase for replaying parked (dead-letter) events on a persistent subscription for the `$all` stream.
     public struct ReplayParked: UnaryUnary {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.ReplayParked.Input
@@ -56,14 +57,19 @@ extension PersistentSubscriptions.AllStream {
 }
 
 extension PersistentSubscriptions.AllStream.ReplayParked {
+    /// Configuration options for replaying parked events on a persistent subscription for the `$all` stream.
     public struct Options: CommandOptions {
+        /// Controls when the replay of parked events should stop.
         public enum StopAtOption: Sendable {
+            /// Stop replaying when the specified stream position is reached.
             case position(position: Int64)
+            /// Replay all parked events without an upper bound.
             case noLimit
         }
 
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// The stopping condition for the parked event replay.
         public var stopAt: StopAtOption
 
         public init() {

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.Update.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/AllStream/PersistentSubscriptions.AllStream.Update.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.AllStream {
+    /// Usecase for updating a persistent subscription on the `$all` stream.
     public struct Update: UnaryUnary {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.Update.Input
@@ -23,7 +24,9 @@ extension PersistentSubscriptions.AllStream {
             "PersistentSubscriptions.\(Self.self)"
         }
 
+        /// The consumer group name for the persistent subscription being updated.
         public private(set) var group: String
+        /// The updated options to apply to the persistent subscription.
         public private(set) var options: Options
 
         init(group: String, options: Options) {
@@ -31,11 +34,6 @@ extension PersistentSubscriptions.AllStream {
             self.options = options
         }
 
-        /// Constructs the underlying gRPC request message for updating a persistent subscription.
-        ///
-        /// Builds the request based on the stream selection (all streams or a specific stream) and the provided cursor position or revision. Throws an error if the stream identifier cannot be built.
-        ///
-        /// - Throws: An error if building the stream identifier fails.
         /// Constructs the gRPC request message for updating a persistent subscription on all streams.
         ///
         /// - Throws: An error if building the options fails, such as when encoding the position cursor.
@@ -58,10 +56,13 @@ extension PersistentSubscriptions.AllStream {
 }
 
 extension PersistentSubscriptions.AllStream.Update {
+    /// Configuration options for updating a persistent subscription on the `$all` stream.
     public struct Options: CommandOptions, PersistentSubscriptionsSettingsBuildable {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// The updated subscription settings such as consumer strategy, timeouts, and retry behaviour.
         public var settings: PersistentSubscription.UpdateSettings
+        /// The new starting position in the `$all` stream, or `nil` to leave it unchanged.
         public var position: PositionCursor?
 
         public init() {

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/PersistentSubscriptions.Ack.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/PersistentSubscriptions.Ack.swift
@@ -10,10 +10,13 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions {
+    /// Represents a positive acknowledgement (ack) sent to a persistent subscription for one or more processed events.
     public struct Ack: StreamRequestBuildable {
         package typealias UnderlyingRequest = UnderlyingService.Method.Read.Input
 
+        /// The raw subscription identifier used to correlate the acknowledgement with the server.
         public let id: Data
+        /// The UUIDs of the events being acknowledged.
         public let eventIds: [UUID]
 
         init(subscriptionId id: String?, eventIds: [UUID]) {
@@ -37,6 +40,7 @@ extension PersistentSubscriptions {
 }
 
 extension PersistentSubscriptions.Ack {
+    /// Confirmation returned by the server when a persistent subscription is successfully established.
     public struct SubscriptionConfirmation {
         let scriptionId: String
     }

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/PersistentSubscriptions.Nack.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/PersistentSubscriptions.Nack.swift
@@ -10,14 +10,21 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions {
+    /// Represents a negative acknowledgement (nack) sent to a persistent subscription, instructing the server how to handle the specified events.
     public struct Nack: StreamRequestBuildable {
         package typealias UnderlyingRequest = UnderlyingService.Method.Read.Input
 
+        /// The action the server should take for nack'd events.
         public enum Action: Int, Sendable {
+            /// The action is unknown or unspecified.
             case unknown = 0
+            /// Park the event in the dead-letter queue.
             case park = 1
+            /// Retry delivering the event.
             case retry = 2
+            /// Skip the event without further processing.
             case skip = 3
+            /// Stop the persistent subscription.
             case stop = 4
 
             func toEventStoreNack() -> UnderlyingRequest.Nack.Action {

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.Create.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.Create.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.SpecifiedStream {
+    /// Usecase for creating a persistent subscription on a specific named stream.
     public struct Create: UnaryUnary {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.Create.Input
@@ -33,11 +34,6 @@ extension PersistentSubscriptions.SpecifiedStream {
             self.options = options
         }
 
-        /// Constructs the underlying gRPC request message for creating a persistent subscription.
-        ///
-        /// Builds the request based on the selected stream(s), group name, and subscription options, including cursor position and optional filters.
-        ///
-        /// - Returns: The constructed gRPC request message.
         /// Constructs the gRPC request message for creating a persistent subscription on a specified stream.
         ///
         /// - Throws: An error if building the stream identifier fails.
@@ -65,10 +61,13 @@ extension PersistentSubscriptions.SpecifiedStream {
 }
 
 extension PersistentSubscriptions.SpecifiedStream.Create {
+    /// Configuration options for creating a persistent subscription on a specified stream.
     public struct Options: CommandOptions, PersistentSubscriptionsSettingsBuildable {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// The subscription creation settings such as consumer strategy, timeouts, and retry behaviour.
         public var settings: PersistentSubscription.CreateSettings
+        /// The starting revision in the stream from which events will be delivered.
         public var revision: RevisionCursor
 
         public init() {

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.Delete.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.Delete.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.SpecifiedStream {
+    /// Usecase for deleting a persistent subscription group on a specific named stream.
     public struct Delete: UnaryUnary {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.Delete.Input

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.GetInfo.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.GetInfo.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.SpecifiedStream {
+    /// Usecase for retrieving information about a persistent subscription group on a specific named stream.
     public struct GetInfo: UnaryUnary {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.GetInfo.Input

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.List.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.List.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.SpecifiedStream {
+    /// Usecase for listing persistent subscriptions on a specific named stream.
     public struct List: UnaryUnary {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.List.Input

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.Read.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.Read.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.SpecifiedStream {
+    /// Usecase for reading events from a persistent subscription on a specific named stream.
     public struct Read: StreamStream {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.Read.Input
@@ -24,8 +25,11 @@ extension PersistentSubscriptions.SpecifiedStream {
             "PersistentSubscriptions.\(Self.self)"
         }
 
+        /// The stream identifier for the target stream.
         public let streamIdentifier: StreamIdentifier
+        /// The consumer group name for the persistent subscription.
         public let group: String
+        /// The read options for this subscription request.
         public let options: Options
 
         init(stream streamIdentifier: StreamIdentifier, group: String, options: Options) {
@@ -98,10 +102,13 @@ extension PersistentSubscriptions.SpecifiedStream {
 }
 
 extension PersistentSubscriptions.SpecifiedStream.Read {
+    /// Configuration options for reading from a persistent subscription on a specified stream.
     public struct Options: CommandOptions {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// The maximum number of messages to buffer before applying back-pressure.
         public var bufferSize: Int32
+        /// The UUID representation format used for event identifiers in the response.
         public var uuidOption: UUID.Option
 
         public init() {

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.ReplayParked.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.ReplayParked.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.SpecifiedStream {
+    /// Usecase for replaying parked (dead-letter) events on a persistent subscription for a specific named stream.
     public struct ReplayParked: UnaryUnary {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.ReplayParked.Input
@@ -55,14 +56,19 @@ extension PersistentSubscriptions.SpecifiedStream {
 }
 
 extension PersistentSubscriptions.SpecifiedStream.ReplayParked {
+    /// Configuration options for replaying parked events on a persistent subscription for a specified stream.
     public struct Options: CommandOptions {
+        /// Controls when the replay of parked events should stop.
         public enum StopAtOption: Sendable {
+            /// Stop replaying when the specified stream position is reached.
             case position(position: Int64)
+            /// Replay all parked events without an upper bound.
             case noLimit
         }
 
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// The stopping condition for the parked event replay.
         public var stopAt: StopAtOption
 
         public init() {

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.Update.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/Specified/PersistentSubscriptions.SpecifiedStream.Update.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension PersistentSubscriptions.SpecifiedStream {
+    /// Usecase for updating a persistent subscription on a specific named stream.
     public struct Update: UnaryUnary {
         package typealias ServiceClient = PersistentSubscriptions.UnderlyingClient
         package typealias UnderlyingRequest = PersistentSubscriptions.UnderlyingService.Method.Update.Input
@@ -23,8 +24,11 @@ extension PersistentSubscriptions.SpecifiedStream {
             "PersistentSubscriptions.\(Self.self)"
         }
 
+        /// The stream identifier for the target stream being updated.
         public private(set) var streamIdentifier: StreamIdentifier
+        /// The consumer group name for the persistent subscription being updated.
         public private(set) var group: String
+        /// The updated options to apply to the persistent subscription.
         public private(set) var options: Options
 
         public init(streamIdentifier: StreamIdentifier, group: String, options: Options) {
@@ -33,11 +37,6 @@ extension PersistentSubscriptions.SpecifiedStream {
             self.options = options
         }
 
-        /// Constructs the underlying gRPC request message for updating a persistent subscription.
-        ///
-        /// Builds the request based on the stream selection (all streams or a specific stream) and the provided cursor position or revision. Throws an error if the stream identifier cannot be built.
-        ///
-        /// - Throws: An error if building the stream identifier fails.
         /// Constructs the underlying gRPC request message for updating a persistent subscription on a specified stream.
         ///
         /// - Throws: An error if the stream identifier cannot be built.
@@ -65,10 +64,13 @@ extension PersistentSubscriptions.SpecifiedStream {
 }
 
 extension PersistentSubscriptions.SpecifiedStream.Update {
+    /// Configuration options for updating a persistent subscription on a specified stream.
     public struct Options: CommandOptions, PersistentSubscriptionsSettingsBuildable {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// The updated subscription settings such as consumer strategy, timeouts, and retry behaviour.
         public var settings: PersistentSubscription.UpdateSettings
+        /// The new starting revision in the stream, or `nil` to leave it unchanged.
         public var revision: RevisionCursor?
 
         public init() {

--- a/Sources/KurrentDB/Projections/API/Projections+AnyMode.swift
+++ b/Sources/KurrentDB/Projections/API/Projections+AnyMode.swift
@@ -13,32 +13,10 @@ import NIO
 
 //MARK: - Any Mode Projection
 extension Projections where Target == AnyProjectionsTarget {
-    /// Lists all projection statistics across any mode.
+    /// Returns statistics for all projections regardless of mode.
     ///
-    /// This asynchronous function performs a request to retrieve projection statistics
-    /// without restricting to a specific mode (i.e., it uses `.any`). It leverages the
-    /// `Statistics` use case with the `.listAll(mode: .any)` option and returns the
-    /// collected `Statistics.Detail` entries extracted from the streamed response.
-    ///
-    /// Behavior:
-    /// - Builds a `Statistics` use case configured to list all projections for any mode.
-    /// - Executes the use case with the current `selector` and `callOptions`.
-    /// - Iterates over the streamed responses and accumulates their `detail` payloads.
-    /// - If an error occurs during reduction/collection, it wraps it in
-    ///   `KurrentError.internalClientError` with additional context.
-    ///
-    /// - Returns: An array of `Statistics.Detail` representing the details of each projection.
-    ///
-    /// - Throws: `KurrentError` in the following situations:
-    ///   - Any error produced by the `Statistics.perform(selector:callOptions:)` call,
-    ///     such as transport or server-side failures.
-    ///   - `KurrentError.internalClientError` if an error occurs while reducing the
-    ///     streamed response into the result array.
-    ///
-    /// - Note: This method requires an environment with valid `selector` and `callOptions`
-    ///   configured on the `Projections` instance, as well as a functioning GRPC transport.
-    ///
-    /// - SeeAlso: `Statistics`, `Statistics.Options.listAll(mode:)`, `Statistics.Detail`
+    /// - Returns: An array of ``Projection/Detail`` describing every projection on the server.
+    /// - Throws: `KurrentError` if the request fails or the response stream cannot be read.
     public func list() async throws(KurrentError) -> [Projection.Detail] {
         let usecase = Statistics(options: .listAll(mode: .any))
         let response = try await usecase.perform(selector: selector, callOptions: callOptions)
@@ -51,9 +29,9 @@ extension Projections where Target == AnyProjectionsTarget {
         }
     }
 
-    /// Restarts the projection subsystem.
+    /// Restarts the entire projection subsystem on the server.
     ///
-    /// - Throws: `KurrentError` if the restart fails.
+    /// - Throws: `KurrentError` if the server rejects the request or a transport failure occurs.
     public func restartSubsystem() async throws(KurrentError) {
         let usecase = RestartSubsystem()
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)

--- a/Sources/KurrentDB/Projections/API/Projections+ContinuousMode.swift
+++ b/Sources/KurrentDB/Projections/API/Projections+ContinuousMode.swift
@@ -13,12 +13,22 @@ import NIO
 
 //MARK: - Specified Continuous Projection
 extension Projections where Target == SpecifiedContinuousProjectionTarget {
-    /// Creates a continuous projection with the specified query and options.
+    /// Creates a continuous projection on the server with the given query.
+    ///
+    /// ```swift
+    /// let projections = client.projections(of: .continuous(name: "order-stats"))
+    /// try await projections.create(query: """
+    ///     fromAll()
+    ///       .when({ $any: (s, e) => { s.count = (s.count || 0) + 1; } })
+    /// """) {
+    ///     $0.emitEnabled = true
+    /// }
+    /// ```
     ///
     /// - Parameters:
-    ///   - query: The query string defining the projection.
-    ///   - options: The options for creating the projection. Defaults to an empty configuration.
-    /// - Throws: An error if the creation process fails.
+    ///   - query: JavaScript query string that defines the projection logic.
+    ///   - configure: Closure to customise creation options such as emit and track-emitted-streams settings.
+    /// - Throws: `KurrentError` if the server rejects the request or a transport failure occurs.
     public func create(query: String, configure: @Sendable (inout ContinuousCreate.Options) -> Void = { _ in }) async throws(KurrentError) {
         var options = ContinuousCreate.Options()
         configure(&options)
@@ -30,25 +40,10 @@ extension Projections where Target == SpecifiedContinuousProjectionTarget {
 //MARK: - Unspecified Continuous Projection
 extension Projections where Target == UnspecifiedContinuousProjectionTarget {
 
-    /// Retrieves a list of continuous projection statistics from the server.
+    /// Returns statistics for all continuous projections on the server.
     ///
-    /// This method queries the projections service for all continuous projections and
-    /// returns an array of detailed statistics for each one. It constructs a `Statistics`
-    /// use case configured to list all projections in continuous mode, performs the request
-    /// using the current selector and call options, and then reduces the streamed responses
-    /// into a collection of `Statistics.Detail` values.
-    ///
-    /// - Returns: An array of `Statistics.Detail` objects, each describing a continuous projection.
-    ///
-    /// - Throws: `KurrentError` in the following cases:
-    ///   - `.internalClientError` if an error occurs while aggregating the streamed responses.
-    ///   - Any other `KurrentError` that may be thrown by the underlying RPC call initiated by `perform`.
-    ///
-    /// - Important: This call is asynchronous and may perform network I/O. It should be awaited
-    ///   from an asynchronous context.
-    ///
-    /// - Note: The results are derived from a streamed response; if any element in the stream
-    ///   fails to decode or process, the entire operation throws.
+    /// - Returns: An array of ``Projection/Detail`` for each continuous projection.
+    /// - Throws: `KurrentError` if the request fails or the response stream cannot be read.
     public func list() async throws(KurrentError) -> [Projection.Detail] {
         let usecase = Statistics(options: .listAll(mode: .continuous))
         let response = try await usecase.perform(selector: selector, callOptions: callOptions)

--- a/Sources/KurrentDB/Projections/API/Projections+OneTimeMode.swift
+++ b/Sources/KurrentDB/Projections/API/Projections+OneTimeMode.swift
@@ -12,12 +12,10 @@ import Logging
 import NIO
 
 extension Projections where Target == OneTimeProjectionTarget {
-    /// Creates a continuous projection with the specified query and options.
+    /// Creates a one-time projection on the server with the given query.
     ///
-    /// - Parameters:
-    ///   - query: The query string defining the projection.
-    ///   - options: The options for creating the projection. Defaults to an empty configuration.
-    /// - Throws: An error if the creation process fails.
+    /// - Parameter query: JavaScript query string that defines the projection logic.
+    /// - Throws: `KurrentError` if the server rejects the request or a transport failure occurs.
     public func create(query: String) async throws(KurrentError) {
         do {
             let usecase = OneTimeCreate(query: query)
@@ -31,24 +29,10 @@ extension Projections where Target == OneTimeProjectionTarget {
 
 extension Projections where Target == OneTimeProjectionTarget {
 
-    /// Retrieves a list of one-time projection statistics.
+    /// Returns statistics for all one-time projections on the server.
     ///
-    /// This asynchronous method queries the server for all one-time projections and
-    /// returns their detailed statistics. Internally, it:
-    /// - Constructs a `Statistics` use case configured to list all projections in `.oneTime` mode.
-    /// - Performs the request using the current `selector` and `callOptions`.
-    /// - Streams and reduces the server responses into an array of `Statistics.Detail`.
-    ///
-    /// - Returns: An array of `Statistics.Detail` describing each one-time projection.
-    ///
-    /// - Throws: `KurrentError`
-    ///   - `.internalClientError` if an error occurs while reducing or processing the streamed responses,
-    ///     with a reason describing the underlying cause.
-    ///   - Any other `KurrentError` propagated from the use case execution.
-    ///
-    /// - Note: This method is available when `Projections.Target` is `OneTimeProjectionTarget`.
-    ///
-    /// - SeeAlso: `Statistics`, `Statistics.Detail`, `OneTimeProjectionTarget`
+    /// - Returns: An array of ``Projection/Detail`` for each one-time projection.
+    /// - Throws: `KurrentError` if the request fails or the response stream cannot be read.
     public func list() async throws(KurrentError) -> [Projection.Detail] {
         let usecase = Statistics(options: .listAll(mode: .oneTime))
         let response = try await usecase.perform(selector: selector, callOptions: callOptions)

--- a/Sources/KurrentDB/Projections/API/Projections+OneTimeMode.swift
+++ b/Sources/KurrentDB/Projections/API/Projections+OneTimeMode.swift
@@ -15,7 +15,8 @@ extension Projections where Target == OneTimeProjectionTarget {
     /// Creates a one-time projection on the server with the given query.
     ///
     /// - Parameter query: JavaScript query string that defines the projection logic.
-    /// - Throws: `KurrentError` if the server rejects the request or a transport failure occurs.
+    ///
+    /// Errors encountered during creation are logged to stdout but not rethrown.
     public func create(query: String) async throws(KurrentError) {
         do {
             let usecase = OneTimeCreate(query: query)

--- a/Sources/KurrentDB/Projections/API/Projections+TransientMode.swift
+++ b/Sources/KurrentDB/Projections/API/Projections+TransientMode.swift
@@ -13,11 +13,10 @@ import NIO
 
 //MARK: - Specified Transient Projection
 extension Projections where Target == SpecifiedTransientProjectionTarget {
-    /// Creates a transient projection with the specified query.
+    /// Creates a transient projection on the server with the given query.
     ///
-    /// - Parameters:
-    ///   - query: The query string defining the projection.
-    /// - Throws: An error if the creation process fails.
+    /// - Parameter query: JavaScript query string that defines the projection logic.
+    /// - Throws: `KurrentError` if the server rejects the request or a transport failure occurs.
     public func create(query: String) async throws(KurrentError) {
         let usecase = TransientCreate(name: target.name, query: query)
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
@@ -26,17 +25,11 @@ extension Projections where Target == SpecifiedTransientProjectionTarget {
 
 //MARK: - Unspecified Transient Projection
 extension Projections where Target == UnspecifiedTransientProjectionTarget {
-    
-    /// Lists all transient projections and returns their detailed statistics.
+
+    /// Returns statistics for all transient projections on the server.
     ///
-    /// This asynchronous method queries the server for all projections in transient mode
-    /// and aggregates their detailed information into a single array.
-    ///
-    /// - Returns: An array of `Statistics.Detail` representing each transient projection's details.
-    /// - Throws: `KurrentError` if the request fails or if an internal client error occurs while
-    ///           aggregating the response stream.
-    /// - Note: Internally, this performs a list-all operation scoped to the transient projection mode
-    ///         and reduces the streamed responses into a single result set.
+    /// - Returns: An array of ``Projection/Detail`` for each transient projection.
+    /// - Throws: `KurrentError` if the request fails or the response stream cannot be read.
     public func list() async throws(KurrentError) -> [Projection.Detail] {
         let usecase = Statistics(options: .listAll(mode: .transient))
         let response = try await usecase.perform(selector: selector, callOptions: callOptions)

--- a/Sources/KurrentDB/Projections/KurrentDBClient+Projections.swift
+++ b/Sources/KurrentDB/Projections/KurrentDBClient+Projections.swift
@@ -8,10 +8,10 @@
 // MARK: - Projection Factory Methods
 
 extension KurrentDBClient {
-    /// Creates a projections interface for a specific target type.
+    /// Returns a ``Projections`` service scoped to the given target.
     ///
-    /// - Parameter target: The projection target (e.g., `.continuous(name:)`, `.transient(name:)`, `.onetime`).
-    /// - Returns: A configured ``Projections`` instance.
+    /// - Parameter target: The projection target, such as `.continuous(name:)`, `.transient(name:)`, or `.onetime`.
+    /// - Returns: A ``Projections`` instance configured for the specified target.
     public func projections<Target: ProjectionsTarget>(of target: Target) -> Projections<Target> {
         .init(
             target: target,
@@ -20,17 +20,15 @@ extension KurrentDBClient {
             eventLoopGroup: eventLoopGroup)
     }
 
-    /// Creates a projections interface for a named projection.
-    ///
-    /// Use this to manage (enable, disable, update, delete, reset) or query (state, result, detail)
-    /// an existing projection by name.
+    /// Returns a ``Projections`` service scoped to the named projection.
     ///
     /// ```swift
     /// try await client.projections(name: "my-projection").enable()
     /// let state = try await client.projections(name: "my-projection").state(of: MyState.self)
     /// ```
     ///
-    /// - Parameter name: The projection name.
+    /// - Parameter name: Name of the projection to manage or query.
+    /// - Returns: A ``Projections`` instance targeting the named projection.
     public func projections(name: String) -> Projections<NameTarget> {
         .init(
             target: .init(name: name),
@@ -39,13 +37,14 @@ extension KurrentDBClient {
             eventLoopGroup: eventLoopGroup)
     }
 
-    /// Creates a projections interface for a predefined system projection.
+    /// Returns a ``Projections`` service scoped to a built-in system projection.
     ///
     /// ```swift
     /// try await client.projections(system: .byCategory).enable()
     /// ```
     ///
-    /// - Parameter predefined: The system projection (e.g., `.byCategory`, `.byEventType`, `.byCorrelationId`).
+    /// - Parameter predefined: The system projection to target, such as `.byCategory` or `.byEventType`.
+    /// - Returns: A ``Projections`` instance targeting the specified system projection.
     public func projections(system predefined: NameTarget.Predefined) -> Projections<NameTarget> {
         .init(
             target: .init(predefined: predefined),

--- a/Sources/KurrentDB/Projections/Projections.swift
+++ b/Sources/KurrentDB/Projections/Projections.swift
@@ -11,12 +11,14 @@ import GRPCNIOTransportHTTP2Posix
 import Logging
 import NIO
 
-/// A structure representing a projections service that interacts with a specific projection target.
+/// Projections service scoped to a specific ``ProjectionsTarget``.
 ///
-/// This struct provides methods to manage projections, such as creating, updating, deleting, and retrieving
-/// details or results, depending on the capabilities of the `Target` type.
+/// Obtain an instance via `KurrentDBClient.projections(of:)` or one of its convenience overloads:
 ///
-/// - Parameter Target: The type conforming to `ProjectionsTarget` that defines the projection's behavior.
+/// ```swift
+/// let projections = client.projections(of: .continuous(name: "order-stats"))
+/// try await projections.enable()
+/// ```
 public final class Projections<Target: ProjectionsTarget>: GRPCConcreteService {
     /// The underlying gRPC client type used for communication.
     package typealias UnderlyingClient = EventStore_Client_Projections_Projections.Client<HTTP2ClientTransport.Posix>
@@ -24,17 +26,11 @@ public final class Projections<Target: ProjectionsTarget>: GRPCConcreteService {
     internal let selector: NodeSelector
     internal let callOptions: CallOptions
     internal let eventLoopGroup: EventLoopGroup
+    /// Target that scopes and constrains the available projection operations.
     public let target: Target
 
     package let serviceName: String = "event_store.client.projections.projections"
 
-    /// Initializes a new `Projections` instance with the specified target and settings.
-    ///
-    /// - Parameters:
-    ///   - target: The projection target to operate on.
-    ///   - settings: The client settings for gRPC communication.
-    ///   - callOptions: The call options for gRPC requests. Defaults to `.defaults`.
-    ///   - eventLoopGroup: The event loop group for asynchronous operations. Defaults to a singleton multi-threaded group.
     init(target: Target, selector: NodeSelector, callOptions: CallOptions = .defaults, eventLoopGroup: EventLoopGroup = .singletonMultiThreadedEventLoopGroup) {
         self.target = target
         self.selector = selector
@@ -48,7 +44,7 @@ public final class Projections<Target: ProjectionsTarget>: GRPCConcreteService {
 extension Projections where Target: ProjectionControlable {
     /// Enables the projection.
     ///
-    /// - Throws: An error if enabling the projection fails.
+    /// - Throws: `KurrentError` if the server rejects the request or a transport failure occurs.
     public func enable() async throws(KurrentError) {
         let usecase = Enable(name: target.name, options: .init())
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
@@ -58,9 +54,9 @@ extension Projections where Target: ProjectionControlable {
 // MARK: - disable / abort
 
 extension Projections where Target: ProjectionControlable {
-    /// Disables the projection and writes a checkpoint.
+    /// Stops the projection and writes a checkpoint before halting.
     ///
-    /// - Throws: An error if disabling the projection fails.
+    /// - Throws: `KurrentError` if the server rejects the request or a transport failure occurs.
     public func disable() async throws(KurrentError) {
         var options = Disable.Options()
         options.writeCheckpoint = true
@@ -68,9 +64,9 @@ extension Projections where Target: ProjectionControlable {
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Aborts the projection without writing a checkpoint.
+    /// Stops the projection immediately without writing a checkpoint.
     ///
-    /// - Throws: An error if aborting the projection fails.
+    /// - Throws: `KurrentError` if the server rejects the request or a transport failure occurs.
     public func abort() async throws(KurrentError) {
         var options = Disable.Options()
         options.writeCheckpoint = false
@@ -82,9 +78,9 @@ extension Projections where Target: ProjectionControlable {
 // MARK: - reset
 
 extension Projections where Target: ProjectionControlable {
-    /// Resets the projection to its initial state.
+    /// Resets the projection to its initial state, discarding all accumulated state.
     ///
-    /// - Throws: An error if resetting the projection fails.
+    /// - Throws: `KurrentError` if the server rejects the request or a transport failure occurs.
     public func reset() async throws(KurrentError) {
         let usecase = Reset(name: target.name, options: .init())
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
@@ -94,10 +90,10 @@ extension Projections where Target: ProjectionControlable {
 // MARK: - delete
 
 extension Projections where Target: ProjectionControlable {
-    /// Deletes the projection with the specified options.
+    /// Deletes the projection from the server.
     ///
-    /// - Parameter options: The options for deleting the projection. Defaults to an empty configuration.
-    /// - Throws: An error if deletion fails.
+    /// - Parameter configure: Closure to customise delete options such as whether to delete emitted streams.
+    /// - Throws: `KurrentError` if the server rejects the request or a transport failure occurs.
     public func delete(configure: @Sendable (inout Delete.Options) -> Void = { _ in }) async throws(KurrentError) {
         var options = Delete.Options()
         configure(&options)
@@ -109,12 +105,12 @@ extension Projections where Target: ProjectionControlable {
 // MARK: - update
 
 extension Projections where Target: ProjectionControlable {
-    /// Updates the projection with an optional query and options.
+    /// Updates the projection's query and options on the server.
     ///
     /// - Parameters:
-    ///   - query: An optional query string to update the projection. If `nil`, the query remains unchanged.
-    ///   - options: The options for updating the projection. Defaults to an empty configuration.
-    /// - Throws: An error if updating fails.
+    ///   - query: Replacement query string, or `nil` to leave the existing query unchanged.
+    ///   - configure: Closure to customise update options such as emit settings.
+    /// - Throws: `KurrentError` if the server rejects the request or a transport failure occurs.
     public func update(query: String?, configure: @Sendable (inout Update.Options) -> Void = { _ in }) async throws(KurrentError) {
         var options = Update.Options()
         configure(&options)
@@ -126,10 +122,10 @@ extension Projections where Target: ProjectionControlable {
 // MARK: - detail
 
 extension Projections where Target: ProjectionControlable {
-    /// Retrieves detailed statistics for the projection.
+    /// Fetches the current runtime statistics for the projection.
     ///
-    /// - Returns: An optional `Statistics.Detail` containing the projection's details, or `nil` if none exist.
-    /// - Throws: An error if retrieving details fails.
+    /// - Returns: A `Projection.Detail` snapshot, or `nil` if the server returns no statistics.
+    /// - Throws: `KurrentError` if the request fails or the response cannot be read.
     public func detail() async throws(KurrentError) -> Projection.Detail? {
         let usecase = Statistics(options: .specified(name: target.name))
         let response = try await usecase.perform(selector: selector, callOptions: callOptions)
@@ -145,13 +141,13 @@ extension Projections where Target: ProjectionControlable {
 // MARK: - get result / state
 
 extension Projections where Target: ProjectionControlable {
-    /// Retrieves the result of the projection decoded to a specified type.
+    /// Fetches the computed result of the projection and decodes it to the given type.
     ///
     /// - Parameters:
-    ///   - _: The type to decode the result into, conforming to `Decodable`.
-    ///   - options: The options for retrieving the result. Defaults to an empty configuration.
-    /// - Returns: An optional decoded result of type `DecodeType`, or `nil` if decoding fails.
-    /// - Throws: An error if the operation or decoding fails.
+    ///   - _: The `Decodable` type to decode the result into.
+    ///   - configure: Closure to customise result options such as the partition key.
+    /// - Returns: The decoded result, or `nil` if the server returns an empty response.
+    /// - Throws: `KurrentError.decodingError` if the response cannot be decoded; `KurrentError` for transport failures.
     public func result<DecodeType: Decodable>(of _: DecodeType.Type, configure: @Sendable (inout Result.Options) -> Void = { _ in }) async throws(KurrentError) -> DecodeType? {
         var options = Result.Options()
         configure(&options)
@@ -166,13 +162,13 @@ extension Projections where Target: ProjectionControlable {
         }
     }
 
-    /// Retrieves the state of the projection decoded to a specified type.
+    /// Fetches the current state of the projection and decodes it to the given type.
     ///
     /// - Parameters:
-    ///   - _: The type to decode the state into, conforming to `Decodable`.
-    ///   - options: The options for retrieving the state. Defaults to an empty configuration.
-    /// - Returns: An optional decoded state of type `DecodeType`, or `nil` if decoding fails.
-    /// - Throws: An error if the operation or decoding fails.
+    ///   - _: The `Decodable` type to decode the state into.
+    ///   - configure: Closure to customise state options such as the partition key.
+    /// - Returns: The decoded state, or `nil` if the server returns an empty response.
+    /// - Throws: `KurrentError.decodingError` if the response cannot be decoded; `KurrentError` for transport failures.
     public func state<DecodeType: Decodable>(of _: DecodeType.Type, configure: @Sendable (inout State.Options) -> Void = { _ in }) async throws(KurrentError) -> DecodeType? {
         var options = State.Options()
         configure(&options)

--- a/Sources/KurrentDB/Projections/Target/AnyProjectionsTarget.swift
+++ b/Sources/KurrentDB/Projections/Target/AnyProjectionsTarget.swift
@@ -3,14 +3,13 @@
 //  KurrentDB
 //
 
-/// A generic target representing all projections.
-///
-/// Used to perform operations on all projections, such as listing or restarting the subsystem.
+/// Target representing all projections across every mode.
 public struct AnyProjectionsTarget: ProjectionsTarget {
+    /// Creates an any-mode projections target.
     public init() {}
 }
 
-extension ProjectionsTarget where Self == AnyProjectionsTarget{
+extension ProjectionsTarget where Self == AnyProjectionsTarget {
     /// Returns a target representing all projections in any mode.
     public static var anyMode: AnyProjectionsTarget {
         .init()

--- a/Sources/KurrentDB/Projections/Target/NameTarget.swift
+++ b/Sources/KurrentDB/Projections/Target/NameTarget.swift
@@ -3,37 +3,38 @@
 //  KurrentDB
 //
 
-/// A target for a specific named projection, regardless of its mode.
-///
-/// Use this when you want to address a projection by name for control operations
-/// (enable, disable, update, delete, reset) without constraining it to a particular type.
+/// Target for a named projection, independent of its operational mode.
 public struct NameTarget: ProjectionsTarget, ProjectionControlable {
+    /// Well-known built-in system projections.
     public enum Predefined: String, Sendable {
-        /// Represents the `$by_category` system projection.
+        /// The `$by_category` system projection.
         case byCategory = "$by_category"
-        /// Represents the `$by_correlation_id` system projection.
+        /// The `$by_correlation_id` system projection.
         case byCorrelationId = "$by_correlation_id"
-        /// Represents the `$by_event_type` system projection.
+        /// The `$by_event_type` system projection.
         case byEventType = "$by_event_type"
-        /// Represents the `$stream_by_category` system projection.
+        /// The `$stream_by_category` system projection.
         case streamByCategory = "$stream_by_category"
-        /// Represents the `$streams` system projection.
+        /// The `$streams` system projection.
         case streams = "$streams"
     }
 
+    /// Name of the target projection.
     public let name: String
 
+    /// Creates a target for the projection with the given name.
     public init(name: String) {
         self.name = name
     }
 
+    /// Creates a target for a predefined system projection.
     public init(predefined: Predefined) {
         name = predefined.rawValue
     }
 }
 
 extension ProjectionsTarget where Self == NameTarget {
-    /// Creates a target for a specific projection identified by name, regardless of its mode.
+    /// Returns a target for the named projection, regardless of its mode.
     public static func anyMode(name: String) -> Self {
         .init(name: name)
     }

--- a/Sources/KurrentDB/Projections/Target/OneTimeProjectionTarget.swift
+++ b/Sources/KurrentDB/Projections/Target/OneTimeProjectionTarget.swift
@@ -3,8 +3,9 @@
 //  KurrentDB
 //
 
-/// A target for one-time (ephemeral) projections that run to completion and then stop.
+/// Target for one-time projections that process existing events once and then stop.
 public struct OneTimeProjectionTarget: ProjectionsTarget {
+    /// Creates a one-time projection target.
     public init() {}
 }
 

--- a/Sources/KurrentDB/Projections/Target/ProjectionControlable.swift
+++ b/Sources/KurrentDB/Projections/Target/ProjectionControlable.swift
@@ -3,6 +3,8 @@
 //  KurrentDB
 //
 
+/// Marks a projection target as supporting control operations by exposing the projection name.
 public protocol ProjectionControlable {
+    /// Name of the projection to control.
     var name: String { get }
 }

--- a/Sources/KurrentDB/Projections/Target/ProjectionsTarget.swift
+++ b/Sources/KurrentDB/Projections/Target/ProjectionsTarget.swift
@@ -3,38 +3,5 @@
 //  KurrentDB
 //
 
-/// A protocol representing a target for projection operations in KurrentDB.
-///
-/// A **target** serves two key purposes in the Projections API:
-///
-/// ## 1. Specifies the Operation Scope (Where)
-///
-/// The target identifies which projection(s) the operation applies to:
-/// - `NameTarget`: Operates on a specific named projection
-/// - `SpecifiedContinuousProjectionTarget`: Operates on a continuous projection with specific name
-/// - `OneTimeProjectionTarget`: Operates on one-time projections (scope is execution-based)
-/// - `SpecifiedTransientProjectionTarget`: Operates on a transient projection with specific name
-/// - `AnyProjectionsTarget`: Operates across all projections
-///
-/// ## 2. Constrains Available Operations (What)
-///
-/// Through protocol composition, different target types enable different capabilities:
-/// - Targets conforming to `ProjectionControlable` support enable, disable, update, delete, reset operations
-/// - `OneTimeProjectionTarget` only supports creation
-/// - `AnyProjectionsTarget` supports listing and subsystem restart operations
-///
-/// ## Usage
-///
-/// Create targets using static factory methods:
-///
-/// ```swift
-/// let named      = ProjectionsTarget.anyMode(name: "my-projection")
-/// let continuous = ProjectionsTarget.continuous(name: "order-stats")
-/// let oneTime    = ProjectionsTarget.onetime
-/// let transient  = ProjectionsTarget.transient(name: "temp-analysis")
-/// let all        = ProjectionsTarget.anyMode
-/// ```
-///
-/// - Note: This protocol is marked as `Sendable`.
-/// - SeeAlso: `ProjectionControlable`, `NameTarget`, `AnyProjectionsTarget`
+/// Identifies the scope of a projection operation and constrains the available API surface.
 public protocol ProjectionsTarget: Sendable {}

--- a/Sources/KurrentDB/Projections/Target/SpecifiedContinuousProjectionTarget.swift
+++ b/Sources/KurrentDB/Projections/Target/SpecifiedContinuousProjectionTarget.swift
@@ -3,15 +3,14 @@
 //  KurrentDB
 //
 
-/// A target representing a named continuous projection.
-///
-/// Supports both creation and control operations (enable, disable, update, etc.).
+/// Target for a named continuous projection, supporting both creation and control operations.
 public struct SpecifiedContinuousProjectionTarget: ProjectionsTarget, ProjectionControlable {
+    /// Name of the continuous projection.
     public let name: String
 }
 
-extension ProjectionsTarget where Self == SpecifiedContinuousProjectionTarget{
-    /// Creates a target for a continuous projection with the given name.
+extension ProjectionsTarget where Self == SpecifiedContinuousProjectionTarget {
+    /// Returns a target for the continuous projection with the given name.
     public static func continuous(name: String) -> SpecifiedContinuousProjectionTarget {
         .init(name: name)
     }

--- a/Sources/KurrentDB/Projections/Target/SpecifiedTransientProjectionTarget.swift
+++ b/Sources/KurrentDB/Projections/Target/SpecifiedTransientProjectionTarget.swift
@@ -3,15 +3,14 @@
 //  KurrentDB
 //
 
-/// A target representing a named transient projection.
-///
-/// Supports both creation and control operations (enable, disable, delete, etc.).
+/// Target for a named transient projection, supporting both creation and control operations.
 public struct SpecifiedTransientProjectionTarget: ProjectionsTarget, ProjectionControlable {
+    /// Name of the transient projection.
     public let name: String
 }
 
-extension ProjectionsTarget where Self == SpecifiedTransientProjectionTarget{
-    /// Creates a target for a transient projection with the given name.
+extension ProjectionsTarget where Self == SpecifiedTransientProjectionTarget {
+    /// Returns a target for the transient projection with the given name.
     public static func transient(name: String) -> SpecifiedTransientProjectionTarget {
         .init(name: name)
     }

--- a/Sources/KurrentDB/Projections/Target/UnspecifiedContinuousProjectionTarget.swift
+++ b/Sources/KurrentDB/Projections/Target/UnspecifiedContinuousProjectionTarget.swift
@@ -3,15 +3,13 @@
 //  KurrentDB
 //
 
-/// A target for continuous projections where the name is provided at creation time.
-///
-/// Does not conform to `ProjectionControlable` — use ``SpecifiedContinuousProjectionTarget``
-/// or ``NameTarget`` for control operations.
+/// Target for continuous projections when the name is supplied at creation time rather than up front.
 public struct UnspecifiedContinuousProjectionTarget: ProjectionsTarget {
+    /// Creates an unspecified continuous projection target.
     public init() {}
 }
 
-extension ProjectionsTarget where Self == UnspecifiedContinuousProjectionTarget{
+extension ProjectionsTarget where Self == UnspecifiedContinuousProjectionTarget {
     /// Returns a target for creating continuous projections without a pre-specified name.
     public static var anyContinuous: UnspecifiedContinuousProjectionTarget {
         .init()

--- a/Sources/KurrentDB/Projections/Target/UnspecifiedTransientProjectionTarget.swift
+++ b/Sources/KurrentDB/Projections/Target/UnspecifiedTransientProjectionTarget.swift
@@ -3,15 +3,13 @@
 //  KurrentDB
 //
 
-/// A target for transient projections where the name is provided at creation time.
-///
-/// Does not conform to `ProjectionControlable` — use ``SpecifiedTransientProjectionTarget``
-/// or ``NameTarget`` for control operations.
+/// Target for transient projections when the name is supplied at creation time rather than up front.
 public struct UnspecifiedTransientProjectionTarget: ProjectionsTarget {
+    /// Creates an unspecified transient projection target.
     public init() {}
 }
 
-extension ProjectionsTarget where Self == UnspecifiedTransientProjectionTarget{
+extension ProjectionsTarget where Self == UnspecifiedTransientProjectionTarget {
     /// Returns a target for creating transient projections without a pre-specified name.
     public static var anyTransient: UnspecifiedTransientProjectionTarget {
         .init()

--- a/Sources/KurrentDB/Streams/API/Streams+AllStreamsTarget.swift
+++ b/Sources/KurrentDB/Streams/API/Streams+AllStreamsTarget.swift
@@ -8,12 +8,12 @@
 
 // MARK: - All Streams Operations
 
-/// Provides operations for all streams.
+/// Operations available on the `$all` stream.
 extension Streams where Target == AllStreamsTarget {
-    /// Reads events from all available streams.
+    /// Reads events from the `$all` stream.
     ///
-    /// - Parameter configure: A closure to configure the read operation, such as filters or limits. Defaults to no-op.
-    /// - Returns: An asynchronous throwing stream of read responses containing events from all streams.
+    /// - Parameter configure: Closure to configure ``ReadAll/Options`` (position, direction, filter, limit). Defaults to no-op.
+    /// - Returns: An async throwing stream of `ReadAll.Response` values.
     /// - Throws: `KurrentError` if the read operation fails.
     public func read(configure: @Sendable (inout ReadAll.Options) -> Void = { _ in }) async throws(KurrentError) -> AsyncThrowingStream<ReadAll.Response, Error> {
         var options = ReadAll.Options()
@@ -22,11 +22,11 @@ extension Streams where Target == AllStreamsTarget {
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Subscribes to all event streams, delivering events as they occur.
+    /// Subscribes to live events from the `$all` stream.
     ///
-    /// - Parameter configure: A closure to configure subscription options, including filters and starting position. Defaults to no-op.
-    /// - Returns: A subscription that receives events from all streams.
-    /// - Throws: `KurrentError` if the subscription fails.
+    /// - Parameter configure: Closure to configure ``SubscribeAll/Options`` (starting position, filter). Defaults to no-op.
+    /// - Returns: A ``Streams/Subscription`` that delivers events as they are committed.
+    /// - Throws: `KurrentError` if the subscription cannot be established.
     public func subscribe(configure: @Sendable (inout SubscribeAll.Options) -> Void = { _ in }) async throws(KurrentError) -> Streams.Subscription {
         var options = SubscribeAll.Options()
         configure(&options)

--- a/Sources/KurrentDB/Streams/API/Streams+ProjectionStream.swift
+++ b/Sources/KurrentDB/Streams/API/Streams+ProjectionStream.swift
@@ -6,17 +6,17 @@
 //
 
 
-/// Provides operations for projection streams.
+/// Operations available on projection streams.
 extension Streams where Target == ProjectionStream {
-    /// The identifier of the projection stream.
+    /// Identifier of the projection stream.
     public var identifier: StreamIdentifier {
         target.identifier
     }
 
-    /// Subscribes to events from the specified projection stream.
+    /// Subscribes to live events from the projection stream.
     ///
-    /// - Parameter configure: A closure to configure subscription options. Defaults to no-op.
-    /// - Returns: A subscription that receives events from the stream.
+    /// - Parameter configure: Closure to configure ``Subscribe/Options`` (starting position). Defaults to no-op.
+    /// - Returns: A ``Streams/Subscription`` that delivers events from the projection stream.
     /// - Throws: `KurrentError` if the subscription cannot be established.
     public func subscribe(configure: @Sendable (inout Subscribe.Options) -> Void = { _ in }) async throws(KurrentError) -> Subscription {
         var options = Subscribe.Options()
@@ -29,39 +29,22 @@ extension Streams where Target == ProjectionStream {
 // MARK: - Multiple Streams Operations
 
 extension Streams where Target == MultiStreamsTarget {
-    /// Appends a batch of pre-constructed stream events using an append session. (KurrentDB > 25.1)
+    /// Appends fully-formed stream events across multiple streams in a single session (requires KurrentDB 25.1+).
     ///
-    /// Use this when you already have fully-formed `StreamEvent` values (including
-    /// their event IDs, types, content type, and data) and want to persist them in
-    /// a single session. This is useful for advanced scenarios like idempotent
-    /// writes, preserving event IDs across retries, or when events are built
-    /// incrementally by upstream systems.
-    ///
-    /// - Parameter events: The collection of `StreamEvent` values to append in order.
-    /// - Returns: An `AppendSession.Response` describing the outcome of the session,
-    ///   including the next expected revision and any server-assigned positions.
-    /// - Throws: `KurrentError` if the session could not be established or the write
-    ///   fails, for example due to version conflicts, access issues, or transport errors.
+    /// - Parameter events: ``StreamEvent`` values to append, each carrying its target stream, event ID, type, and payload.
+    /// - Returns: An `AppendSession.Response` with the next expected revisions and server-assigned positions.
+    /// - Throws: `KurrentError` if the session fails, a version conflict occurs, or access is denied.
     @discardableResult
     public func append(events: [StreamEvent]) async throws(KurrentError) -> AppendSession.Response {
         let usecase = AppendSession(streamEvents: events)
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Appends a variadic list of pre-constructed stream events in a single append session.  (KurrentDB > 25.1)
+    /// Appends a variadic list of fully-formed stream events in a single session (requires KurrentDB 25.1+).
     ///
-    /// Use this when you already have fully formed `StreamEvent` values (including IDs,
-    /// types, content type, and payload) and want to persist them together while preserving
-    /// ordering and event IDs. This is useful for idempotent writes, retries, or when events
-    /// are assembled upstream.
-    ///
-    /// - Parameter events: One or more `StreamEvent` values to append in order.
-    /// - Returns: An `AppendSession.Response` describing the outcome, including the next
-    ///   expected revision and any server-assigned positions.
-    /// - Throws: `KurrentError` if the session cannot be established or the write fails
-    ///   (e.g., due to version conflicts, access issues, or transport errors).
-    /// - Note: Events are appended in the order provided and are not transformed; ensure
-    ///   each `StreamEvent` carries the desired identifiers and content metadata.
+    /// - Parameter events: One or more ``StreamEvent`` values to append in order.
+    /// - Returns: An `AppendSession.Response` with the next expected revisions and server-assigned positions.
+    /// - Throws: `KurrentError` if the session fails, a version conflict occurs, or access is denied.
     @discardableResult
     public func append(events: StreamEvent...) async throws(KurrentError) -> AppendSession.Response {
         let usecase = AppendSession(streamEvents: events)

--- a/Sources/KurrentDB/Streams/API/Streams+SpecifiedStreamTarget.swift
+++ b/Sources/KurrentDB/Streams/API/Streams+SpecifiedStreamTarget.swift
@@ -9,18 +9,20 @@ import Foundation
 
 // MARK: - Specified Stream Operations
 
-/// Provides operations for specific streams conforming to `SpecifiedStreamTarget`.
+/// Operations available when the target identifies a single named stream.
 extension Streams where Target: SpecifiedStreamTarget {
-    /// The identifier of the specific stream.
+    /// Identifier of the target stream.
     public var identifier: StreamIdentifier {
         target.identifier
     }
 
-    /// Sets metadata for the specified stream.
+    /// Sets metadata on the specified stream.
     ///
-    /// - Parameter metadata: The metadata to associate with the stream.
-    /// - Returns: An `Append.Response` indicating the result of the operation.
-    /// - Throws: An error if the operation fails.
+    /// - Parameters:
+    ///   - metadata: The ``StreamMetadata`` to store.
+    ///   - expectedRevision: The revision expected at the metadata stream before writing. Defaults to `.any`.
+    /// - Returns: An `Append.Response` containing the result of the metadata write.
+    /// - Throws: `KurrentError` if the write fails or a revision conflict occurs.
     @discardableResult
     public func setMetadata(metadata: StreamMetadata, expectedRevision: StreamRevision = .any) async throws(KurrentError) -> Append.Response {
         var options = Append.Options()
@@ -34,21 +36,10 @@ extension Streams where Target: SpecifiedStreamTarget {
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Retrieves the metadata associated with the specified stream.
+    /// Retrieves the latest metadata for the stream.
     ///
-    /// - Parameter cursor: The position in the stream from which to retrieve metadata, defaulting to `.end`.
-    /// - Returns: The `StreamMetadata` if available, otherwise `nil`.
-    /// Retrieves the latest metadata for the stream, if available.
-    ///
-    /// Reads the most recent metadata event from the stream's metadata stream (`$$<streamName>`), decodes it as JSON, and returns it as a `StreamMetadata` object. Returns `nil` if no metadata event exists.
-    ///
-    /// - Throws: `KurrentError` if the metadata event is missing, not in JSON format, or if a parsing or client error occurs.
-    ///
-    /// Retrieves the latest metadata for the stream, decoding it as `StreamMetadata`.
-    ///
-    /// Reads the most recent metadata event from the stream's associated metadata stream. Returns the decoded metadata if present, or `nil` if no metadata event exists. Throws an error if the event data is not valid JSON or if a client or parsing error occurs.
-    ///
-    /// - Returns: The latest `StreamMetadata` if available, or `nil` if no metadata event exists.
+    /// - Returns: The decoded ``StreamMetadata``, or `nil` if no metadata event has been written.
+    /// - Throws: `KurrentError` if the metadata event is not JSON-encoded or a client error occurs.
     @discardableResult
     public func getMetadata() async throws(KurrentError) -> StreamMetadata? {
         var options = Streams.Read.Options()
@@ -80,13 +71,19 @@ extension Streams where Target: SpecifiedStreamTarget {
         }
     }
 
-    /// Appends a list of events to the specified stream.
+    /// Appends events to the stream.
+    ///
+    /// ```swift
+    /// try await client.streams(specified: "orders").append(events: [event]) {
+    ///     $0.expectedRevision = .streamExists
+    /// }
+    /// ```
     ///
     /// - Parameters:
-    ///   - events: An array of events to append.
-    ///   - configure: A closure to configure append options. Defaults to no-op.
-    /// - Returns: An `Append.Response` indicating the result of the operation.
-    /// - Throws: An error if the append operation fails.
+    ///   - events: Events to append.
+    ///   - configure: Closure to configure ``Append/Options`` (e.g., expected revision). Defaults to no-op.
+    /// - Returns: An `Append.Response` with the server-assigned positions.
+    /// - Throws: `KurrentError` if the append fails or a revision conflict occurs.
     @discardableResult
     public func append(events: [EventData], configure: @Sendable (inout Append.Options) -> Void = { _ in }) async throws(KurrentError) -> Append.Response {
         var options = Append.Options()
@@ -95,23 +92,33 @@ extension Streams where Target: SpecifiedStreamTarget {
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Appends a variadic list of events to the specified stream.
+    /// Appends a variadic list of events to the stream.
     ///
     /// - Parameters:
-    ///   - events: A variadic list of events to append.
-    ///   - configure: A closure to configure append options. Defaults to no-op.
-    /// - Returns: An `Append.Response` indicating the result of the operation.
-    /// - Throws: An error if the append operation fails.
+    ///   - events: One or more events to append.
+    ///   - configure: Closure to configure ``Append/Options``. Defaults to no-op.
+    /// - Returns: An `Append.Response` with the server-assigned positions.
+    /// - Throws: `KurrentError` if the append fails or a revision conflict occurs.
     @discardableResult
     public func append(events: EventData..., configure: @Sendable (inout Append.Options) -> Void = { _ in }) async throws(KurrentError) -> Append.Response {
         try await append(events: events, configure: configure)
     }
 
-    /// Reads events from the specified stream.
+    /// Reads events from the stream.
     ///
-    /// - Parameter configure: A closure to configure read options, such as revision range or direction. Defaults to no-op.
-    /// - Returns: An asynchronous throwing stream of read responses containing events from the stream.
-    /// - Throws: `KurrentError` if the read operation fails.
+    /// ```swift
+    /// let responses = try await client.streams(specified: "orders").read {
+    ///     $0.direction = .backward
+    ///     $0.limit = 10
+    /// }
+    /// for try await response in responses {
+    ///     let event = try response.event
+    /// }
+    /// ```
+    ///
+    /// - Parameter configure: Closure to configure ``Read/Options`` (direction, limit, starting revision). Defaults to no-op.
+    /// - Returns: An async throwing stream of ``Streams/ReadResponse`` values.
+    /// - Throws: `KurrentError` if the stream is not found or the read fails.
     public func read(configure: @Sendable (inout Read.Options) -> Void = { _ in }) async throws(KurrentError) -> AsyncThrowingStream<Read.Response, Error> {
         var options = Read.Options()
         configure(&options)
@@ -119,11 +126,11 @@ extension Streams where Target: SpecifiedStreamTarget {
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Subscribes to events from the specified stream.
+    /// Subscribes to live events from the stream.
     ///
-    /// - Parameter configure: A closure to configure subscription options. Defaults to no-op.
-    /// - Returns: A subscription to the stream's events.
-    /// - Throws: `KurrentError` if the subscription fails.
+    /// - Parameter configure: Closure to configure ``Subscribe/Options`` (starting position, filter). Defaults to no-op.
+    /// - Returns: A ``Streams/Subscription`` that delivers events as they are appended.
+    /// - Throws: `KurrentError` if the subscription cannot be established.
     public func subscribe(configure: @Sendable (inout Subscribe.Options) -> Void = { _ in }) async throws(KurrentError) -> Subscription {
         var options = Subscribe.Options()
         configure(&options)
@@ -131,11 +138,11 @@ extension Streams where Target: SpecifiedStreamTarget {
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Deletes the specified stream.
+    /// Soft-deletes the stream, allowing it to be recreated by appending new events.
     ///
-    /// - Parameter configure: A closure to configure delete options. Defaults to no-op.
-    /// - Returns: A `Delete.Response` indicating the result of the operation.
-    /// - Throws: An error if the delete operation fails.
+    /// - Parameter configure: Closure to configure ``Delete/Options`` (expected revision). Defaults to no-op.
+    /// - Returns: A `Delete.Response` with the resulting stream position.
+    /// - Throws: `KurrentError` if the delete fails or a revision conflict occurs.
     @discardableResult
     public func delete(configure: @Sendable (inout Delete.Options) -> Void = { _ in }) async throws(KurrentError) -> Delete.Response {
         var options = Delete.Options()
@@ -144,11 +151,11 @@ extension Streams where Target: SpecifiedStreamTarget {
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Marks the specified stream as permanently deleted (tombstoned).
+    /// Permanently tombstones the stream so it cannot be recreated.
     ///
-    /// - Parameter configure: A closure to configure tombstone options. Defaults to no-op.
-    /// - Returns: A `Tombstone.Response` indicating the result of the operation.
-    /// - Throws: An error if the tombstone operation fails.
+    /// - Parameter configure: Closure to configure ``Tombstone/Options`` (expected revision). Defaults to no-op.
+    /// - Returns: A `Tombstone.Response` with the resulting stream position.
+    /// - Throws: `KurrentError` if the tombstone operation fails or a revision conflict occurs.
     @discardableResult
     public func tombstone(configure: @Sendable (inout Tombstone.Options) -> Void = { _ in }) async throws(KurrentError) -> Tombstone.Response {
         var options = Tombstone.Options()

--- a/Sources/KurrentDB/Streams/KurrentDBClient+Streams.swift
+++ b/Sources/KurrentDB/Streams/KurrentDBClient+Streams.swift
@@ -6,60 +6,37 @@
 //
 
 extension KurrentDBClient {
-    /// Creates a type-safe streams interface for the specified target.
-    ///
-    /// The target determines the scope and available operations:
-    /// - `.specified(_:)` — single named stream (append, read, subscribe, delete)
-    /// - `.all` — global `$all` stream (read, subscribe)
-    /// - `.multiple` — batch operations across multiple streams (requires server 25.1+)
+    /// Returns a ``Streams`` instance scoped to the given target.
     ///
     /// ```swift
     /// let orders = client.streams(of: .specified("orders"))
     /// try await orders.append(events: events)
     ///
-    /// let allEvents = try await client.streams(of: .all).read()
+    /// for try await response in try await client.streams(of: .all).read() { }
     /// ```
     ///
-    /// - Parameter target: The stream target. Use static factories like `.specified(_:)`, `.all`, or `.multiple`.
-    /// - Returns: A configured ``Streams`` instance ready for stream operations.
-    ///
-    /// - SeeAlso: ``StreamsTarget``, ``SpecifiedStream``, ``AllStreamsTarget``, ``MultiStreamsTarget``
+    /// - Parameter target: The stream target. Use static factories such as `.specified(_:)`, `.all`, or `.multiple`.
+    /// - Returns: A ``Streams`` instance configured for the given target.
     public func streams<Target: StreamsTarget>(of target: Target) -> Streams<Target> {
         .init(target: target, selector: selector, callOptions: defaultCallOptions, eventLoopGroup: eventLoopGroup)
     }
 }
 
 extension KurrentDBClient {
-    /// Creates a streams interface for a specific stream by name.
+    /// Returns a ``Streams`` instance for a named stream.
     ///
-    /// - Parameter name: The name of the stream to access.
-    ///
-    /// - Returns: A `Streams<SpecifiedStream>` instance configured for the named stream.
-    ///
-    /// - SeeAlso: `streams(of:)`, `SpecifiedStream`
+    /// - Parameter name: Name of the stream to access.
+    /// - Returns: A `Streams<SpecifiedStream>` configured for the named stream.
     public func streams(specified name: String) -> Streams<SpecifiedStream> {
         streams(of: .specified(name))
     }
 
-    /// Accesses the multi-streams interface for batch operations across multiple streams.
-    ///
-    /// - Returns: A `Streams<MultiStreamsTarget>` instance for multi-stream operations.
-    ///
-    /// - Note: Multi-stream operations require KurrentDB server version 25.1 or later.
-    ///
-    /// - SeeAlso: `MultiStreamsTarget`
+    /// Streams interface for batch append operations across multiple streams (requires KurrentDB 25.1+).
     public var multiStreams: Streams<MultiStreamsTarget> {
         streams(of: .multiple)
     }
 
-    /// Accesses the `$all` stream for global event log operations.
-    ///
-    /// - Returns: A `Streams<AllStreamsTarget>` instance for `$all` stream operations.
-    ///
-    /// - Warning: Reading from `$all` can return a very large number of events. Always
-    ///   use appropriate filtering and pagination when working with the global log.
-    ///
-    /// - SeeAlso: `AllStreamsTarget`
+    /// Streams interface for the global `$all` event log.
     public var allStreams: Streams<AllStreamsTarget> {
         streams(of: .all)
     }

--- a/Sources/KurrentDB/Streams/Streams.ReadResponse.swift
+++ b/Sources/KurrentDB/Streams/Streams.ReadResponse.swift
@@ -8,10 +8,13 @@
 import GRPCEncapsulates
 
 extension Streams {
+    /// Response returned by a stream read operation.
     public enum ReadResponse: Sendable, GRPCResponse {
         package typealias UnderlyingMessage = UnderlyingClient.UnderlyingService.Method.Read.Output
 
+        /// An event whose original record could not be resolved, optionally carrying its link event.
         case unserviceable(link: RecordedEvent?)
+        /// A successfully resolved event.
         case event(readEvent: ReadEvent)
 
         // TODO: Not sure how to request to get first_stream_position, last_stream_position, first_all_stream_position.
@@ -43,6 +46,11 @@ extension Streams {
 }
 
 extension Streams.ReadResponse {
+    /// Extracts the resolved ``ReadEvent`` from this response.
+    ///
+    /// - Returns: The ``ReadEvent`` when the response is `.event`.
+    /// - Throws: `KurrentError.unservicableEventLink` if the event link cannot be resolved,
+    ///   or `KurrentError.resourceNotFound` if no event is present.
     public var event: ReadEvent {
         get throws(KurrentError) {
             return switch self {

--- a/Sources/KurrentDB/Streams/Streams.Subscription.swift
+++ b/Sources/KurrentDB/Streams/Streams.Subscription.swift
@@ -10,41 +10,18 @@ import GRPCEncapsulates
 import SwiftProtobuf
 
 extension Streams {
-    /// A subscription to a stream, providing access to events and metadata.
-    ///
-    /// `Subscription` represents a subscription to a stream, enabling you to:
-    /// - Receive events through an asynchronous throwing stream.
-    /// - Access the subscription's unique identifier, if provided by the server.
-    ///
-    /// ## Usage
-    ///
-    /// Subscribing to all streams and processing events:
-    /// ```swift
-    /// let streams = Streams(target: StreamsTarget.all, settings: .localhost())
-    /// let subscription = try await streams.subscribe(from: .start)
-    /// for try await event in subscription.events {
-    ///     print("Received event: \(event)")
-    /// }
-    /// ```
-    ///
-    /// - Note: This class conforms to `Sendable`, ensuring safe use across concurrency contexts.
+    /// Live subscription to a stream, delivering events as an async throwing stream.
     public struct Subscription: Sendable {
-        /// An asynchronous stream delivering events or errors from the subscription.
+        /// Async throwing stream of events received from the server.
         public let events: AsyncThrowingStream<ReadEvent, Error>
 
-        /// The unique identifier of the subscription, if provided by the server.
+        /// Server-assigned identifier for this subscription, if provided.
         public let subscriptionId: String?
 
         package let continuation: AsyncThrowingStream<ReadEvent, any Error>.Continuation
 
         package let task: Task<Void, Never>?
 
-        /// Initializes a `Subscription` instance with an event stream and subscription ID.
-        ///
-        /// - Parameters:
-        ///   - events: The asynchronous stream of `ReadEvent` objects.
-        ///   - subscriptionId: An optional subscription identifier.
-        ///   - task: An optional task handle for the background streaming task.
         package init(events: AsyncThrowingStream<ReadEvent, Error>, continuation: AsyncThrowingStream<ReadEvent, any Error>.Continuation, subscriptionId: String?, task: Task<Void, Never>? = nil) {
             self.events = events
             self.continuation = continuation
@@ -52,6 +29,7 @@ extension Streams {
             self.task = task
         }
 
+        /// Cancels the subscription and terminates the event stream.
         public func cancel() {
             task?.cancel()
             continuation.finish()

--- a/Sources/KurrentDB/Streams/Streams.swift
+++ b/Sources/KurrentDB/Streams/Streams.swift
@@ -12,54 +12,22 @@ import GRPCNIOTransportHTTP2Posix
 import Logging
 import NIO
 
-/// A generic gRPC service for handling event streams.
+/// gRPC service for interacting with KurrentDB event streams.
 ///
-/// `Streams` enables interaction with event streams through operations such as appending, reading,
-/// subscribing, deleting, and managing metadata. It is a concrete implementation of `GRPCConcreteService`.
-///
-/// The type parameter `Target` determines the scope of the stream:
-/// - `SpecifiedStream`: A single named stream
-/// - `AllStreamsTarget`: The global `$all` stream containing all events
-/// - `MultiStreamsTarget`: Batch operations across multiple streams
-/// - `ProjectionStream`: A projection-generated stream
-///
-/// ## Usage
-///
-/// Obtain a `Streams` instance through `KurrentDBClient`:
+/// Obtain a `Streams` instance via ``KurrentDBClient`` factory methods. The `Target` type
+/// determines which operations are available (append, read, subscribe, delete, metadata).
 ///
 /// ```swift
 /// let client = KurrentDBClient(settings: .localhost())
 ///
-/// // Append to a specific stream
-/// let stream = client.streams(specified: "orders")
-/// try await stream.append(events: [event])
+/// // Append to a named stream
+/// try await client.streams(specified: "orders").append(events: [event])
 ///
 /// // Read from $all
-/// let responses = try await client.allStreams.read()
-/// for try await response in responses {
+/// for try await response in try await client.allStreams.read() {
 ///     print(response)
 /// }
 /// ```
-///
-/// - Note: `Streams` instances are obtained via `KurrentDBClient` factory methods and should not be
-///   constructed directly.
-///
-/// ### Topics
-/// #### Specific Stream Operations
-/// - ``setMetadata(metadata:)``
-/// - ``getMetadata(cursor:)``
-/// - ``append(events:options:)``
-/// - ``read(cursor:options:)``
-/// - ``subscribe(from:options:)``
-/// - ``delete(options:)``
-/// - ``tombstone(options:)``
-///
-/// #### Projection Stream Operations
-/// - ``subscribe(from:options:)-swift.struct-8y6e8``
-///
-/// #### All Streams Operations
-/// - ``read(cursor:options:)-6h8h2``
-/// - ``subscribe(from:options:)-9gq2e``
 public final class Streams<Target: StreamsTarget>: GRPCConcreteService {
     /// The underlying client type used for gRPC communication.
     package typealias UnderlyingClient = EventStore_Client_Streams_Streams.Client<HTTP2ClientTransport.Posix>
@@ -73,16 +41,9 @@ public final class Streams<Target: StreamsTarget>: GRPCConcreteService {
     /// The event loop group handling asynchronous tasks.
     internal let eventLoopGroup: EventLoopGroup
 
-    /// The target stream, defining the scope of operations (e.g., specific stream or all streams).
+    /// The target that defines the scope of stream operations.
     public let target: Target
 
-    /// Initializes a `Streams` instance with a target and node selector.
-    ///
-    /// - Parameters:
-    ///   - target: The stream target (e.g., `SpecifiedStream`, `AllStreamsTarget`, or `MultiStreamsTarget`).
-    ///   - selector: The node selector used to resolve the gRPC connection endpoint.
-    ///   - callOptions: The gRPC call options, defaulting to `.defaults`.
-    ///   - eventLoopGroup: The event loop group, defaulting to a shared multi-threaded group.
     init(target: Target, selector: NodeSelector, callOptions: CallOptions = .defaults, eventLoopGroup: EventLoopGroup = .singletonMultiThreadedEventLoopGroup) {
         self.target = target
         self.selector = selector

--- a/Sources/KurrentDB/Streams/Streams.swift
+++ b/Sources/KurrentDB/Streams/Streams.swift
@@ -32,7 +32,7 @@ public final class Streams<Target: StreamsTarget>: GRPCConcreteService {
     /// The underlying client type used for gRPC communication.
     package typealias UnderlyingClient = EventStore_Client_Streams_Streams.Client<HTTP2ClientTransport.Posix>
 
-    /// The client settings required for establishing a gRPC connection.
+    /// Node selector used to resolve the target gRPC endpoint.
     internal let selector: NodeSelector
 
     /// The gRPC call options.

--- a/Sources/KurrentDB/Streams/Target/AllStreamsTarget.swift
+++ b/Sources/KurrentDB/Streams/Target/AllStreamsTarget.swift
@@ -3,11 +3,11 @@
 //  KurrentDB
 //
 
-/// Represents the global `$all` stream containing all events across all streams.
+/// Target representing the global `$all` stream that contains every event in the database.
 public struct AllStreamsTarget: StreamsTarget {}
 
 extension StreamsTarget where Self == AllStreamsTarget {
-    /// Returns a target representing the `$all` stream.
+    /// Target for the `$all` stream.
     public static var all: AllStreamsTarget {
         .init()
     }

--- a/Sources/KurrentDB/Streams/Target/AnyStreamTarget.swift
+++ b/Sources/KurrentDB/Streams/Target/AnyStreamTarget.swift
@@ -3,5 +3,5 @@
 //  KurrentDB
 //
 
-/// A generic stream target used in contexts where a specific stream type is not required.
+/// Type-erased stream target for contexts where a concrete target type is not required.
 public struct AnyStreamTarget: StreamsTarget {}

--- a/Sources/KurrentDB/Streams/Target/MultiStreamsTarget.swift
+++ b/Sources/KurrentDB/Streams/Target/MultiStreamsTarget.swift
@@ -3,11 +3,11 @@
 //  KurrentDB
 //
 
-/// Represents a batch target for operations across multiple streams simultaneously.
+/// Target for batch append operations across multiple streams (requires KurrentDB 25.1+).
 public struct MultiStreamsTarget: StreamsTarget {}
 
 extension StreamsTarget where Self == MultiStreamsTarget {
-    /// Returns a target for batch multi-stream operations.
+    /// Target for multi-stream batch operations.
     public static var multiple: MultiStreamsTarget {
         .init()
     }

--- a/Sources/KurrentDB/Streams/Target/ProjectionStream.swift
+++ b/Sources/KurrentDB/Streams/Target/ProjectionStream.swift
@@ -3,9 +3,9 @@
 //  KurrentDB
 //
 
-/// Represents a system projection stream.
+/// Target representing a system projection stream.
 public struct ProjectionStream: SpecifiedStreamTarget {
-    /// The identifier for the stream.
+    /// Unique identifier for the projection stream.
     public private(set) var identifier: StreamIdentifier
 
     init(identifier: StreamIdentifier) {
@@ -14,12 +14,12 @@ public struct ProjectionStream: SpecifiedStreamTarget {
 }
 
 extension StreamsTarget where Self == ProjectionStream {
-    /// Creates a `ProjectionStream` scoped to events of a specific type.
+    /// Creates a ``ProjectionStream`` for the `$et-<eventType>` category stream.
     public static func byEventType(_ eventType: String) -> ProjectionStream {
         .init(identifier: .init(name: "$et-\(eventType)"))
     }
 
-    /// Creates a `ProjectionStream` scoped to streams with a specific prefix.
+    /// Creates a ``ProjectionStream`` for the `$ce-<prefix>` category stream.
     public static func byStream(prefix: String) -> ProjectionStream {
         .init(identifier: .init(name: "$ce-\(prefix)"))
     }

--- a/Sources/KurrentDB/Streams/Target/SpecifiedStream.swift
+++ b/Sources/KurrentDB/Streams/Target/SpecifiedStream.swift
@@ -5,9 +5,9 @@
 
 import Foundation
 
-/// Represents a specific named stream.
+/// Target representing a single named stream.
 public struct SpecifiedStream: SpecifiedStreamTarget {
-    /// The identifier for the stream.
+    /// Unique identifier for the stream.
     public private(set) var identifier: StreamIdentifier
 
     init(identifier: StreamIdentifier) {
@@ -16,12 +16,12 @@ public struct SpecifiedStream: SpecifiedStreamTarget {
 }
 
 extension StreamsTarget where Self == SpecifiedStream {
-    /// Creates a `SpecifiedStream` using a `StreamIdentifier`.
+    /// Creates a ``SpecifiedStream`` from an existing ``StreamIdentifier``.
     public static func specified(_ identifier: StreamIdentifier) -> SpecifiedStream {
         .init(identifier: identifier)
     }
 
-    /// Creates a `SpecifiedStream` identified by a name and encoding.
+    /// Creates a ``SpecifiedStream`` from a stream name string.
     public static func specified(_ name: String, encoding: String.Encoding = .utf8) -> SpecifiedStream {
         .init(identifier: .init(name: name, encoding: encoding))
     }

--- a/Sources/KurrentDB/Streams/Target/SpecifiedStream.swift
+++ b/Sources/KurrentDB/Streams/Target/SpecifiedStream.swift
@@ -30,6 +30,7 @@ extension StreamsTarget where Self == SpecifiedStream {
 extension SpecifiedStream: ExpressibleByStringLiteral {
     public typealias StringLiteralType = String
 
+    /// Creates a stream target from a string literal name.
     public init(stringLiteral value: String) {
         identifier = .init(name: value)
     }

--- a/Sources/KurrentDB/Streams/Target/SpecifiedStreamTarget.swift
+++ b/Sources/KurrentDB/Streams/Target/SpecifiedStreamTarget.swift
@@ -3,10 +3,8 @@
 //  KurrentDB
 //
 
-/// A protocol for stream targets that have a specific identifier.
-///
-/// Conforming types must provide a `StreamIdentifier` to uniquely identify the stream.
+/// Stream target that identifies a single named stream.
 public protocol SpecifiedStreamTarget: StreamsTarget {
-    /// The identifier for the stream.
+    /// Unique identifier for the stream.
     var identifier: StreamIdentifier { get }
 }

--- a/Sources/KurrentDB/Streams/Target/StreamsTarget.swift
+++ b/Sources/KurrentDB/Streams/Target/StreamsTarget.swift
@@ -3,37 +3,5 @@
 //  KurrentDB
 //
 
-/// A protocol representing a target for stream operations in KurrentDB.
-///
-/// A **target** serves two key purposes in the Streams API:
-///
-/// ## 1. Specifies the Operation Scope (Where)
-///
-/// The target identifies which streams the operation applies to:
-/// - `SpecifiedStream`: Operates on a specific named stream
-/// - `AllStreamsTarget`: Operates on the global `$all` stream containing all events
-/// - `MultiStreamsTarget`: Operates on multiple streams simultaneously
-/// - `ProjectionStream`: Operates on system projection streams
-///
-/// ## 2. Constrains Available Operations (What)
-///
-/// Through protocol composition, different target types enable different capabilities:
-/// - Targets conforming to `SpecifiedStreamTarget` support append, read, delete, and subscription operations
-/// - `AllStreamsTarget` only supports read and subscription operations (cannot append to `$all`)
-/// - `MultiStreamsTarget` only supports batch append operations
-/// - The type system prevents invalid operations at compile time
-///
-/// ## Usage
-///
-/// Create targets using static factory methods:
-///
-/// ```swift
-/// let orders = StreamsTarget.specified("orders")
-/// let all = StreamsTarget.all
-/// let multi = StreamsTarget.multiple
-/// let byType = StreamsTarget.byEventType("OrderCreated")
-/// ```
-///
-/// - Note: This protocol is marked as `Sendable`.
-/// - SeeAlso: `SpecifiedStreamTarget`, `AllStreamsTarget`, `MultiStreamsTarget`, `ProjectionStream`
+/// Marker protocol for types that identify the scope of a stream operation.
 public protocol StreamsTarget: Sendable {}

--- a/Sources/KurrentDB/Streams/Usecase/All/Streams.ReadAll.swift
+++ b/Sources/KurrentDB/Streams/Usecase/All/Streams.ReadAll.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Streams where Target == AllStreamsTarget {
+    /// Usecase that reads events from the global `$all` stream.
     public struct ReadAll: UnaryStream {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.Read.Input
@@ -24,6 +25,7 @@ extension Streams where Target == AllStreamsTarget {
             "Streams.\(Self.self)"
         }
 
+        /// Options controlling which events are returned and in what order.
         public let options: Options
 
         init(options: Options) {
@@ -66,14 +68,19 @@ extension Streams where Target == AllStreamsTarget {
 }
 
 extension Streams.ReadAll where Target == AllStreamsTarget {
+    /// A position-and-direction pair used to anchor a `$all` read operation.
     public struct CursorPointer: Sendable {
+        /// Global log position at which to anchor the read.
         public let position: StreamPosition
+        /// Direction in which to read from the anchor position.
         public let direction: Direction
 
+        /// Creates a forward cursor anchored at the given commit and prepare positions.
         public static func forwardOn(commitPosition: UInt64, preparePosition: UInt64) -> Self {
             .init(position: .at(commitPosition: commitPosition, preparePosition: preparePosition), direction: .forward)
         }
 
+        /// Creates a backward cursor anchored at the given commit and prepare positions.
         public static func backwardFrom(commitPosition: UInt64, preparePosition: UInt64) -> Self {
             .init(position: .at(commitPosition: commitPosition, preparePosition: preparePosition), direction: .backward)
         }
@@ -81,16 +88,24 @@ extension Streams.ReadAll where Target == AllStreamsTarget {
 }
 
 extension Streams.ReadAll {
+    /// Options that control `$all` read behaviour.
     public struct Options: CommandOptions {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// Global log position at which the read starts.
         public var position: PositionCursor
+        /// Direction in which events are returned.
         public var direction: Direction
+        /// When `true`, linked events are resolved to their targets.
         public var resolveLinksEnabled: Bool
+        /// Maximum number of events to return.
         public var limit: UInt64
+        /// UUID representation used in event metadata.
         public var uuidOption: UUIDOption
+        /// Compatibility level passed to the server.
         public var compatibility: UInt32
 
+        /// Initialises options with sensible defaults (start from beginning, forward, max events, string UUIDs).
         public init() {
             resolveLinksEnabled = false
             limit = .max

--- a/Sources/KurrentDB/Streams/Usecase/All/Streams.SubscribeAll.swift
+++ b/Sources/KurrentDB/Streams/Usecase/All/Streams.SubscribeAll.swift
@@ -10,6 +10,7 @@ import GRPCEncapsulates
 import GRPCNIOTransportHTTP2Posix
 
 extension Streams where Target == AllStreamsTarget {
+    /// Usecase that opens a live subscription to the global `$all` stream.
     public struct SubscribeAll: UnaryStream {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ReadAll.UnderlyingRequest
@@ -24,6 +25,7 @@ extension Streams where Target == AllStreamsTarget {
             "Streams.\(Self.self)"
         }
 
+        /// Options controlling the subscription start position and filter.
         public let options: Options
 
         init(options: Options) {
@@ -70,17 +72,25 @@ extension Streams where Target == AllStreamsTarget {
 }
 
 extension Streams.SubscribeAll where Target == AllStreamsTarget {
+    /// A single message received from a `$all` stream subscription.
     public struct Response: GRPCResponse {
+        /// Payload variants delivered by the `$all` subscription.
         public enum Content: Sendable {
+            /// A resolved event read from the stream.
             case event(readEvent: ReadEvent)
+            /// Server confirmation carrying the assigned subscription ID.
             case confirmation(subscriptionId: String)
+            /// First commit position seen on the stream.
             case commitPosition(firstStream: UInt64)
+            /// Last commit position seen on the stream.
             case commitPosition(lastStream: UInt64)
+            /// Last position across all streams.
             case position(lastAllStream: StreamPosition)
         }
 
         package typealias UnderlyingMessage = UnderlyingResponse
 
+        /// The content delivered in this response message.
         public var content: Content
 
         init(content: Content) {
@@ -137,14 +147,20 @@ extension Streams.SubscribeAll where Target == AllStreamsTarget {
 }
 
 extension Streams.SubscribeAll where Target == AllStreamsTarget {
+    /// Options that control `$all` subscription behaviour.
     public struct Options: CommandOptions {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// Global log position at which the subscription starts.
         public var position: PositionCursor
+        /// When `true`, linked events are resolved to their targets.
         public var resolveLinksEnabled: Bool
+        /// UUID representation used in event metadata.
         public var uuidOption: UUIDOption
+        /// Optional filter applied server-side to reduce event noise.
         public var filter: SubscriptionFilter?
 
+        /// Initialises options with sensible defaults (start from end, string UUIDs, no filter, no link resolution).
         public init() {
             resolveLinksEnabled = false
             uuidOption = .string

--- a/Sources/KurrentDB/Streams/Usecase/Specified/Streams.Append.swift
+++ b/Sources/KurrentDB/Streams/Usecase/Specified/Streams.Append.swift
@@ -8,6 +8,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Streams {
+    /// Usecase that appends one or more events to a single named stream.
     public struct Append: StreamUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.Append.Input
@@ -21,8 +22,11 @@ extension Streams {
             "Streams.\(Self.self)"
         }
 
+        /// Events to be appended to the stream.
         public let events: [EventData]
+        /// Identifier of the target stream.
         public let identifier: StreamIdentifier
+        /// Options controlling the append behaviour (e.g. expected revision).
         public private(set) var options: Options
 
         init(to identifier: StreamIdentifier, events: [EventData], options: Options = .init()) {
@@ -68,10 +72,13 @@ extension Streams {
 }
 
 extension Streams.Append {
+    /// Response returned after a successful append operation.
     public struct Response: GRPCResponse {
         package typealias UnderlyingMessage = UnderlyingResponse
 
+        /// Revision of the stream after the append, or `nil` if the stream no longer exists.
         public let currentRevision: UInt64?
+        /// Global log position of the append, or `nil` when unavailable.
         public let position: StreamPosition?
 
         init(currentRevision: UInt64?, position: StreamPosition?) {
@@ -118,11 +125,14 @@ extension Streams.Append {
 }
 
 extension Streams.Append {
+    /// Options that control append behaviour.
     public struct Options: CommandOptions {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// Expected stream revision used for optimistic concurrency checks.
         public var expectedRevision: StreamRevision
 
+        /// Initialises options with `expectedRevision` set to `.any`.
         public init() {
             expectedRevision = .any
         }

--- a/Sources/KurrentDB/Streams/Usecase/Specified/Streams.AppendSession.swift
+++ b/Sources/KurrentDB/Streams/Usecase/Specified/Streams.AppendSession.swift
@@ -10,6 +10,7 @@ import GRPCNIOTransportHTTP2Posix
 import SwiftProtobuf
 
 extension Streams {
+    /// Usecase that appends events to one or more streams in a single session call.
     public struct AppendSession: StreamUnary {
         package typealias ServiceClient = Kurrentdb_Protocol_V2_Streams_StreamsService.Client<HTTP2ClientTransport.Posix>
         package typealias UnderlyingRequest = Kurrentdb_Protocol_V2_Streams_StreamsService.Method.AppendSession.Input
@@ -23,6 +24,7 @@ extension Streams {
             "Streams.\(Self.self)"
         }
 
+        /// Stream events to be written across one or more target streams.
         public let streamEvents: [StreamEvent]
 
         init(streamEvents: [StreamEvent]) {
@@ -61,6 +63,7 @@ extension Streams {
 }
 
 extension Streams.AppendSession.Response {
+    /// Result for a single stream written during an append session.
     public struct AppendedResult: Sendable {
         let streamIdentifier: StreamIdentifier
         let currentRevision: UInt64
@@ -75,10 +78,13 @@ extension Streams.AppendSession.Response {
 }
 
 extension Streams.AppendSession {
+    /// Response returned after a completed append session.
     public struct Response: GRPCResponse {
         package typealias UnderlyingMessage = UnderlyingResponse
 
+        /// Per-stream append results included in the session response.
         public let results: [AppendedResult]
+        /// Global log position of the session commit.
         public let position: StreamPosition
 
         init(results: [AppendedResult], position: StreamPosition) {

--- a/Sources/KurrentDB/Streams/Usecase/Specified/Streams.Delete.swift
+++ b/Sources/KurrentDB/Streams/Usecase/Specified/Streams.Delete.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Streams {
+    /// Usecase that soft-deletes a stream, allowing it to be recreated later.
     public struct Delete: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.Delete.Input
@@ -22,7 +23,9 @@ extension Streams {
             "Streams.\(Self.self)"
         }
 
+        /// Identifier of the stream to delete.
         public let streamIdentifier: StreamIdentifier
+        /// Options controlling the delete behaviour (e.g. expected revision).
         public let options: Options
 
         init(to streamIdentifier: StreamIdentifier, options: Options) {
@@ -47,9 +50,11 @@ extension Streams {
 }
 
 extension Streams.Delete {
+    /// Response returned after a successful stream deletion.
     public struct Response: GRPCResponse {
         package typealias UnderlyingMessage = UnderlyingResponse
 
+        /// Global log position of the delete operation, or `nil` when unavailable.
         public internal(set) var position: StreamPosition?
 
         package init(from message: UnderlyingMessage) throws {
@@ -66,11 +71,14 @@ extension Streams.Delete {
 }
 
 extension Streams.Delete {
+    /// Options that control stream delete behaviour.
     public struct Options: CommandOptions {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// Expected stream revision used for optimistic concurrency checks.
         public var expectedRevision: StreamRevision
 
+        /// Initialises options with `expectedRevision` set to `.streamExists`.
         public init() {
             expectedRevision = .streamExists
         }

--- a/Sources/KurrentDB/Streams/Usecase/Specified/Streams.Subscribe.swift
+++ b/Sources/KurrentDB/Streams/Usecase/Specified/Streams.Subscribe.swift
@@ -10,6 +10,7 @@ import GRPCEncapsulates
 import GRPCNIOTransportHTTP2Posix
 
 extension Streams where Target: SpecifiedStreamTarget {
+    /// Usecase that opens a live subscription to a single named stream.
     public struct Subscribe: UnaryStream {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = Read.UnderlyingRequest
@@ -24,9 +25,12 @@ extension Streams where Target: SpecifiedStreamTarget {
             "Streams.\(Self.self)"
         }
 
+        /// Identifier of the stream to subscribe to.
         public let streamIdentifier: StreamIdentifier
+        /// Options controlling the subscription behaviour.
         public let options: Options
 
+        /// Creates a subscribe usecase for the given stream and options.
         public init(from streamIdentifier: StreamIdentifier, options: Options) {
             self.streamIdentifier = streamIdentifier
             self.options = options
@@ -73,17 +77,25 @@ extension Streams where Target: SpecifiedStreamTarget {
 }
 
 extension Streams.Subscribe {
+    /// A single message received from a stream subscription.
     public struct Response: GRPCResponse {
+        /// Payload variants delivered by the subscription.
         public enum Content: Sendable {
+            /// A resolved event read from the stream.
             case event(readEvent: ReadEvent)
+            /// Server confirmation carrying the assigned subscription ID.
             case confirmation(subscriptionId: String)
+            /// First commit position seen on the stream.
             case commitPosition(firstStream: UInt64)
+            /// Last commit position seen on the stream.
             case commitPosition(lastStream: UInt64)
+            /// Last position across all streams.
             case position(lastAllStream: StreamPosition)
         }
 
         package typealias UnderlyingMessage = UnderlyingResponse
 
+        /// The content delivered in this response message.
         public var content: Content
 
         init(content: Content) {
@@ -140,13 +152,18 @@ extension Streams.Subscribe {
 }
 
 extension Streams.Subscribe {
+    /// Options that control stream subscription behaviour.
     public struct Options: CommandOptions {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// When `true`, linked events are resolved to their targets.
         public var resolveLinksEnabled: Bool
+        /// UUID representation used in event metadata.
         public var uuidOption: UUIDOption
+        /// Stream revision from which the subscription starts.
         public var revision: RevisionCursor
 
+        /// Initialises options with sensible defaults (start from end, string UUIDs, no link resolution).
         public init() {
             resolveLinksEnabled = false
             uuidOption = .string

--- a/Sources/KurrentDB/Streams/Usecase/Specified/Streams.Tombstone.swift
+++ b/Sources/KurrentDB/Streams/Usecase/Specified/Streams.Tombstone.swift
@@ -9,6 +9,7 @@ import GRPCEncapsulates
 import GRPCNIOTransportHTTP2Posix
 
 extension Streams {
+    /// Usecase that permanently tombstones a stream, preventing it from being recreated.
     public struct Tombstone: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.Tombstone.Input
@@ -22,7 +23,9 @@ extension Streams {
             "Streams.\(Self.self)"
         }
 
+        /// Identifier of the stream to tombstone.
         public let streamIdentifier: StreamIdentifier
+        /// Options controlling the tombstone behaviour (e.g. expected revision).
         public let options: Options
 
         init(to streamIdentifier: StreamIdentifier, options: Options) {
@@ -48,9 +51,11 @@ extension Streams {
 }
 
 extension Streams.Tombstone {
+    /// Response returned after a stream is successfully tombstoned.
     public struct Response: GRPCResponse {
         package typealias UnderlyingMessage = UnderlyingResponse
 
+        /// Global log position of the tombstone operation, or `nil` when unavailable.
         public internal(set) var position: StreamPosition?
 
         package init(from message: UnderlyingMessage) throws {
@@ -67,11 +72,14 @@ extension Streams.Tombstone {
 }
 
 extension Streams.Tombstone {
+    /// Options that control tombstone behaviour.
     public struct Options: CommandOptions {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// Expected stream revision used for optimistic concurrency checks.
         public var expectedRevision: StreamRevision
 
+        /// Initialises options with `expectedRevision` defaulting to `.streamExists`.
         public init(expectedRevision: StreamRevision = .streamExists) {
             self.expectedRevision = expectedRevision
         }

--- a/Sources/KurrentDB/Users/KurrentDBClient+Users.swift
+++ b/Sources/KurrentDB/Users/KurrentDBClient+Users.swift
@@ -8,7 +8,7 @@
 // MARK: - User Management Factory Methods
 
 extension KurrentDBClient {
-    /// Accesses the user management service for cluster-wide user operations (create, list).
+    /// User management service for cluster-wide operations such as account creation.
     ///
     /// ```swift
     /// let user = try await client.users.create(
@@ -18,15 +18,11 @@ extension KurrentDBClient {
     ///     groups: ["$ops"]
     /// )
     /// ```
-    ///
-    /// - SeeAlso: ``user(_:)``
     public var users: Users<AllUsersTarget> {
         .init(target: .all, selector: selector, callOptions: defaultCallOptions, eventLoopGroup: eventLoopGroup)
     }
 
-    /// Returns a users interface for a specific user by login name.
-    ///
-    /// Supports operations like enable, disable, update, change password, and details.
+    /// Returns a user management interface scoped to the specified login name.
     ///
     /// ```swift
     /// let details = try await client.user("jane_doe").details()
@@ -34,7 +30,7 @@ extension KurrentDBClient {
     /// ```
     ///
     /// - Parameter loginName: The unique login name of the target user.
-    /// - Returns: A configured ``Users`` instance scoped to the specified user.
+    /// - Returns: A ``Users`` instance scoped to the specified user.
     public func user(_ loginName: String) -> Users<SpecifiedUserTarget> {
         .init(target: .specified(loginName), selector: selector, callOptions: defaultCallOptions, eventLoopGroup: eventLoopGroup)
     }

--- a/Sources/KurrentDB/Users/Target/AllUsersTarget.swift
+++ b/Sources/KurrentDB/Users/Target/AllUsersTarget.swift
@@ -3,17 +3,13 @@
 //  KurrentDB
 //
 
-/// A target representing operations on all users in the KurrentDB system.
-///
-/// Supports user creation operations via `UserCreatable`.
-///
-/// - SeeAlso: `UserCreatable`, `UsersTarget`, `SpecifiedUserTarget`
+/// Target representing the full user collection, enabling account creation operations.
 public struct AllUsersTarget: UserCreatable {
     public init() {}
 }
 
 extension UsersTarget where Self == AllUsersTarget {
-    /// Returns a target representing all users (for creation operations).
+    /// Target representing all users, used for account creation.
     public static var all: AllUsersTarget {
         .init()
     }

--- a/Sources/KurrentDB/Users/Target/SpecifiedUserTarget.swift
+++ b/Sources/KurrentDB/Users/Target/SpecifiedUserTarget.swift
@@ -3,14 +3,9 @@
 //  KurrentDB
 //
 
-/// A target representing operations on a specific user identified by login name.
-///
-/// Supports account management operations via `UserControllable`:
-/// retrieving details, enabling/disabling, updating profile, and managing credentials.
-///
-/// - SeeAlso: `UserControllable`, `UsersTarget`, `AllUsersTarget`
+/// Target scoped to a single user, enabling account management operations.
 public struct SpecifiedUserTarget: UserControllable {
-    /// The unique login name identifying the target user.
+    /// Login name of the targeted user.
     public let loginName: String
 
     public init(loginName: String) {
@@ -19,7 +14,7 @@ public struct SpecifiedUserTarget: UserControllable {
 }
 
 extension UsersTarget where Self == SpecifiedUserTarget {
-    /// Creates a target for a specific user identified by login name.
+    /// Creates a target scoped to the user with the given login name.
     public static func specified(_ loginName: String) -> SpecifiedUserTarget {
         .init(loginName: loginName)
     }

--- a/Sources/KurrentDB/Users/Target/UserControllable.swift
+++ b/Sources/KurrentDB/Users/Target/UserControllable.swift
@@ -3,18 +3,8 @@
 //  KurrentDB
 //
 
-/// A protocol marking user targets that support control operations on specific users.
-///
-/// Types conforming to `UserControllable` can perform administrative and management operations
-/// on individual user accounts: viewing details, modifying account status, updating
-/// profile information, and managing credentials.
-///
-/// ## Conforming Types
-///
-/// - `SpecifiedUserTarget`: Can control a specific user identified by login name
-///
-/// - SeeAlso: `UserCreatable`, `SpecifiedUserTarget`
+/// Capability protocol for user targets that support management operations on a specific account.
 public protocol UserControllable: UsersTarget {
-    /// The login name uniquely identifying the user to control.
+    /// Login name uniquely identifying the target user.
     var loginName: String { get }
 }

--- a/Sources/KurrentDB/Users/Target/UserCreatable.swift
+++ b/Sources/KurrentDB/Users/Target/UserCreatable.swift
@@ -3,15 +3,5 @@
 //  KurrentDB
 //
 
-/// A protocol marking user targets that support user creation operations.
-///
-/// Types conforming to `UserCreatable` can perform operations that create new user accounts
-/// in the KurrentDB system. This capability is typically associated with targets representing
-/// the entire user base rather than specific individual users.
-///
-/// ## Conforming Types
-///
-/// - `AllUsersTarget`: Can create new users in the system
-///
-/// - SeeAlso: `UserControllable`, `AllUsersTarget`
+/// Capability protocol for user targets that support creating new accounts.
 public protocol UserCreatable: UsersTarget {}

--- a/Sources/KurrentDB/Users/Target/UsersTarget.swift
+++ b/Sources/KurrentDB/Users/Target/UsersTarget.swift
@@ -3,12 +3,5 @@
 //  KurrentDB
 //
 
-/// A protocol representing a target for user management operations in KurrentDB.
-///
-/// The target identifies the scope of user operations and constrains which
-/// methods are available at compile time through protocol conformance:
-/// - `UserCreatable`: targets that support creating new users (`AllUsersTarget`)
-/// - `UserControllable`: targets that support managing a specific user (`SpecifiedUserTarget`)
-///
-/// - SeeAlso: `UserCreatable`, `UserControllable`, `AllUsersTarget`, `SpecifiedUserTarget`
+/// Marker protocol for types that identify the scope of a user management operation.
 public protocol UsersTarget: Sendable {}

--- a/Sources/KurrentDB/Users/Usecase/Users.ChangePassword.swift
+++ b/Sources/KurrentDB/Users/Usecase/Users.ChangePassword.swift
@@ -10,6 +10,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Users {
+    /// Usecase that sends a change-password RPC to KurrentDB.
     public struct ChangePassword: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.ChangePassword.Input
@@ -24,6 +25,7 @@ extension Users {
             "Users.\(Self.self)"
         }
 
+        /// Login name of the user whose password is being changed.
         public let loginName: String
         private let currentPassword: String
         private let newPassword: String

--- a/Sources/KurrentDB/Users/Usecase/Users.Create.swift
+++ b/Sources/KurrentDB/Users/Usecase/Users.Create.swift
@@ -10,6 +10,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Users {
+    /// Usecase that sends a create-user RPC to KurrentDB.
     public struct Create: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.Create.Input

--- a/Sources/KurrentDB/Users/Usecase/Users.Details.swift
+++ b/Sources/KurrentDB/Users/Usecase/Users.Details.swift
@@ -11,6 +11,7 @@ import GRPCEncapsulates
 import GRPCNIOTransportHTTP2Posix
 
 extension Users {
+    /// Usecase that fetches user detail records as a streaming response.
     public struct Details: UnaryStream {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.Details.Input
@@ -25,6 +26,7 @@ extension Users {
             "Users.\(Self.self)"
         }
 
+        /// Login name of the user whose details are being requested.
         public let loginName: String
 
         public init(loginName: String) {
@@ -64,6 +66,7 @@ extension Users {
 }
 
 extension Users.Details {
+    /// Decoded user detail record from a single gRPC response message.
     public struct Response: GRPCResponse {
         package typealias UnderlyingMessage = UnderlyingResponse
 

--- a/Sources/KurrentDB/Users/Usecase/Users.Details.swift
+++ b/Sources/KurrentDB/Users/Usecase/Users.Details.swift
@@ -66,7 +66,7 @@ extension Users {
 }
 
 extension Users.Details {
-    /// Decoded user detail record from a single gRPC response message.
+    /// gRPC response wrapper for user details.
     public struct Response: GRPCResponse {
         package typealias UnderlyingMessage = UnderlyingResponse
 

--- a/Sources/KurrentDB/Users/Usecase/Users.Disable.swift
+++ b/Sources/KurrentDB/Users/Usecase/Users.Disable.swift
@@ -11,6 +11,7 @@ import GRPCEncapsulates
 import GRPCNIOTransportHTTP2Posix
 
 extension Users {
+    /// Usecase that sends a disable-user RPC to KurrentDB.
     public struct Disable: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.Disable.Input
@@ -25,6 +26,7 @@ extension Users {
             "Users.\(Self.self)"
         }
 
+        /// Login name of the user account to disable.
         public let loginName: String
 
         public init(loginName: String) {

--- a/Sources/KurrentDB/Users/Usecase/Users.Enable.swift
+++ b/Sources/KurrentDB/Users/Usecase/Users.Enable.swift
@@ -9,6 +9,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Users {
+    /// Usecase that sends an enable-user RPC to KurrentDB.
     public struct Enable: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.Enable.Input
@@ -23,6 +24,7 @@ extension Users {
             "Users.\(Self.self)"
         }
 
+        /// Login name of the user account to enable.
         public let loginName: String
 
         public init(loginName: String) {

--- a/Sources/KurrentDB/Users/Usecase/Users.ResetPassword.swift
+++ b/Sources/KurrentDB/Users/Usecase/Users.ResetPassword.swift
@@ -10,6 +10,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Users {
+    /// Usecase that sends a reset-password RPC to KurrentDB without requiring the current password.
     public struct ResetPassword: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.ResetPassword.Input
@@ -24,6 +25,7 @@ extension Users {
             "Users.\(Self.self)"
         }
 
+        /// Login name of the user whose password is being reset.
         public let loginName: String
         private let newPassword: String
 

--- a/Sources/KurrentDB/Users/Usecase/Users.Update.swift
+++ b/Sources/KurrentDB/Users/Usecase/Users.Update.swift
@@ -71,7 +71,7 @@ extension Users.Update {
             }
         }
 
-        /// Returns a copy with the given groups appended to the existing group list.
+        /// Appends groups to the existing group list; call ``set(groups:)`` first to initialise the list.
         public func add(groups: UserGroup...) -> Self {
             withCopy { options in
                 options.groups?.append(contentsOf: groups)

--- a/Sources/KurrentDB/Users/Usecase/Users.Update.swift
+++ b/Sources/KurrentDB/Users/Usecase/Users.Update.swift
@@ -10,6 +10,7 @@ import GRPCCore
 import GRPCEncapsulates
 
 extension Users {
+    /// Usecase that sends an update-user RPC to KurrentDB.
     public struct Update: UnaryUnary {
         package typealias ServiceClient = UnderlyingClient
         package typealias UnderlyingRequest = ServiceClient.UnderlyingService.Method.Update.Input
@@ -52,26 +53,32 @@ extension Users {
 }
 
 extension Users.Update {
+    /// Builder for profile fields that can be modified during an update operation.
     public struct Options: CommandOptions {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
+        /// Updated full display name, or `nil` to leave unchanged.
         public fileprivate(set) var fullName: String?
+        /// Updated group memberships, or `nil` to leave unchanged.
         public fileprivate(set) var groups: [UserGroup]?
 
         public init() {}
 
+        /// Returns a copy with `fullName` set to the given value.
         public func set(fullName: String) -> Self {
             withCopy { options in
                 options.fullName = fullName
             }
         }
 
+        /// Returns a copy with the given groups appended to the existing group list.
         public func add(groups: UserGroup...) -> Self {
             withCopy { options in
                 options.groups?.append(contentsOf: groups)
             }
         }
 
+        /// Returns a copy with the group list replaced by the given groups.
         public func set(groups: UserGroup...) -> Self {
             withCopy { options in
                 options.groups = groups

--- a/Sources/KurrentDB/Users/UserDetails.swift
+++ b/Sources/KurrentDB/Users/UserDetails.swift
@@ -7,45 +7,31 @@
 import Foundation
 import GRPCEncapsulates
 
-/// Represents the details of a user.
-///
-/// `UserDetails` contains important information about a user, including their username, full name,
-/// associated groups, last update timestamp, and whether the account is disabled.
-///
-/// - Note: This struct is designed to be used as a part of user management functionalities, typically for
-/// retrieving and updating user information in a user management system.
-///
-/// ## Usage Example:
-/// ```swift
-/// let user = UserDetails(loginName: "john_doe", fullName: "John Doe", groups: ["admin", "user"],
-///                        lastUpdated: Date(), disabled: false)
-/// ```
-///
-/// - SeeAlso: `Users` for the service to manage users and their details.
+/// Snapshot of a KurrentDB user account returned by the Users service.
 public struct UserDetails: Sendable {
-    /// The login name (username) of the user.
+    /// Unique login name identifying the user.
     public var loginName: String
 
-    /// The full name of the user.
+    /// Display name of the user.
     public var fullName: String
 
-    /// The list of groups the user belongs to.
+    /// Groups the user belongs to.
     public var groups: [UserGroup]
 
-    /// The last updated timestamp of the user’s details.
+    /// Timestamp of the most recent update to this user record.
     public var lastUpdated: Date
 
-    /// A flag indicating whether the user’s account is disabled.
+    /// Indicates whether the account is currently disabled.
     public var disabled: Bool
 
-    /// Initializes a `UserDetails` instance with the given user details.
+    /// Creates a `UserDetails` value with the given field values.
     ///
     /// - Parameters:
-    ///   - loginName: The login name (username) of the user.
-    ///   - fullName: The full name of the user.
-    ///   - groups: The groups the user belongs to.
-    ///   - lastUpdated: The date when the user’s details were last updated.
-    ///   - disabled: A flag indicating whether the user’s account is disabled.
+    ///   - loginName: Unique login name for the user.
+    ///   - fullName: Display name of the user.
+    ///   - groups: Groups the user belongs to.
+    ///   - lastUpdated: Date the user record was last modified.
+    ///   - disabled: Whether the account is currently disabled.
     public init(loginName: String, fullName: String, groups: [UserGroup], lastUpdated: Date, disabled: Bool) {
         self.loginName = loginName
         self.fullName = fullName
@@ -56,14 +42,6 @@ public struct UserDetails: Sendable {
 }
 
 extension UserDetails {
-    /// Initializes a `UserDetails` instance from the output of a `Users` service's method.
-    ///
-    /// This initializer converts the underlying message received from the `Users.UnderlyingClient.UnderlyingService.Method.Details.Output.UserDetails`
-    /// into a `UserDetails` struct.
-    ///
-    /// - Parameters:
-    ///   - message: The user details message from the service method output.
-    /// - Throws: An error if the transformation fails.
     package init(from message: Users.UnderlyingClient.UnderlyingService.Method.Details.Output.UserDetails) throws {
         self.init(
             loginName: message.loginName,

--- a/Sources/KurrentDB/Users/UserGroup.swift
+++ b/Sources/KurrentDB/Users/UserGroup.swift
@@ -5,73 +5,34 @@
 //  Created by Grady Zhuo on 2026/2/16.
 //
 
-/// Represents a user group in KurrentDB for role-based access control.
+/// Role-based access control group for a KurrentDB user.
 ///
-/// KurrentDB uses groups to define user permissions. There are two built-in system groups
-/// and support for custom application-defined groups.
-///
-/// ## Built-in Groups
-///
-/// | Group | Description |
-/// |-------|-------------|
-/// | `$admins` | Full access to everything, including user management and all system streams |
-/// | `$ops` | Can perform operational activities (scavenge, shutdown) but restricted to user streams for data access |
-///
-/// ## Custom Groups
-///
-/// Applications can define custom groups for fine-grained access control on specific streams
-/// or projections.
-///
-/// ## Usage
+/// KurrentDB ships with two built-in groups and supports arbitrary custom groups for
+/// application-defined access control.
 ///
 /// ```swift
-/// // Using built-in groups
-/// try await client.users.create(
-///     loginName: "admin-user",
-///     password: "secure_password",
-///     fullName: "Admin User",
-///     groups: [.admins]
-/// )
+/// // String literal initialisation (via ExpressibleByStringLiteral)
+/// let group: UserGroup = "$admins"  // equivalent to .admins
 ///
-/// // Using operational group
+/// // Assign built-in and custom groups when creating a user
 /// try await client.users.create(
-///     loginName: "ops-user",
+///     loginName: "jane_doe",
 ///     password: "secure_password",
-///     fullName: "Ops User",
-///     groups: [.ops]
-/// )
-///
-/// // Using custom groups
-/// try await client.users.create(
-///     loginName: "app-user",
-///     password: "secure_password",
-///     fullName: "App User",
-///     groups: [.ops, .custom("order-writers"), .custom("report-readers")]
+///     fullName: "Jane Doe",
+///     groups: [.admins, .ops, "order-writers"]
 /// )
 /// ```
 public enum UserGroup: Sendable, Equatable, Hashable {
-    /// The `$admins` group with full access to everything in KurrentDB.
-    ///
-    /// Members have full read and write access to all streams, including
-    /// protected system streams (those starting with `$`), and can manage
-    /// other users and perform all operational commands.
+    /// The `$admins` group — full read/write access to all streams and user management.
     case admins
 
-    /// The `$ops` group for operational activities.
-    ///
-    /// Members can perform operational activities like scavenge and shutdown,
-    /// but have standard user access for data streams. They have read/write
-    /// access to user streams (non-`$` streams) by default, but restricted
-    /// access to system streams and user management functions.
+    /// The `$ops` group — permission to perform operational tasks such as scavenge and shutdown.
     case ops
 
-    /// A custom application-defined group.
-    ///
-    /// - Parameter name: The group name. Should not start with `$` to avoid
-    ///   conflicts with system groups.
+    /// A custom application-defined group with the given name.
     case custom(String)
 
-    /// The raw string value sent to KurrentDB.
+    /// Raw string value transmitted to KurrentDB (e.g., `"$admins"`, `"$ops"`, or a custom name).
     public var rawValue: String {
         switch self {
         case .admins:
@@ -83,10 +44,7 @@ public enum UserGroup: Sendable, Equatable, Hashable {
         }
     }
 
-    /// Creates a `UserGroup` from a raw string value.
-    ///
-    /// Automatically maps `$admins` and `$ops` to their respective enum cases,
-    /// and treats all other values as custom groups.
+    /// Creates a `UserGroup` from a raw string, mapping `"$admins"` and `"$ops"` to their enum cases.
     ///
     /// - Parameter rawValue: The group name string.
     public init(rawValue: String) {

--- a/Sources/KurrentDB/Users/Users.swift
+++ b/Sources/KurrentDB/Users/Users.swift
@@ -11,68 +11,17 @@ import GRPCNIOTransportHTTP2Posix
 import Logging
 import NIO
 
-/// A gRPC service for managing user accounts with type-safe target-based operations.
-///
-/// `Users` provides a type-safe interface for user account management using target-based design.
-/// Different operations are available depending on the target type:
-///
-/// ## Target Types
-///
-/// - **AllUsersTarget**: Operations on all users (e.g., creating new users)
-/// - **SpecifiedUserTarget**: Operations on specific users (e.g., details, enable, disable, update)
-///
-/// ## Usage
-///
-/// Creating a new user:
-/// ```swift
-/// let allUsers = Users(target: .all, selector: selector, ...)
-/// let newUser = try await allUsers.create(
-///     loginName: "john_doe",
-///     password: "securePass123",
-///     fullName: "John Doe",
-///     groups: ["$admins", "developers"]
-/// )
-/// ```
-///
-/// Managing a specific user:
-/// ```swift
-/// let userTarget = UsersTarget.user("john_doe")
-/// let users = Users(target: userTarget, selector: selector, ...)
-///
-/// // Get user details
-/// let details = try await users.details()
-///
-/// // Disable user
-/// try await users.disable()
-///
-/// // Change password
-/// try await users.change(password: "newPass", origin: "oldPass")
-/// ```
-///
-/// - Note: This service is built on top of **gRPC** and requires proper authentication.
+/// gRPC service for managing KurrentDB user accounts scoped to a specific target.
 public final class Users<Target: UsersTarget>: GRPCConcreteService {
-    /// The underlying client type used for gRPC communication.
     package typealias UnderlyingClient = EventStore_Client_Users_Users.Client<HTTP2ClientTransport.Posix>
 
-    /// The node selector for routing requests to cluster nodes.
     internal let selector: NodeSelector
-
-    /// The gRPC call options.
     internal let callOptions: CallOptions
-
-    /// The event loop group handling asynchronous tasks.
     internal let eventLoopGroup: EventLoopGroup
 
     /// The target specifying which users this service operates on.
     public let target: Target
 
-    /// Initializes a `Users` instance with a specific target.
-    ///
-    /// - Parameters:
-    ///   - target: The users target specifying the scope of operations.
-    ///   - selector: The node selector for cluster node routing.
-    ///   - callOptions: The gRPC call options, defaulting to `.defaults`.
-    ///   - eventLoopGroup: The event loop group, defaulting to a shared multi-threaded group.
     init(target: Target, selector: NodeSelector, callOptions: CallOptions = .defaults, eventLoopGroup: EventLoopGroup = .singletonMultiThreadedEventLoopGroup) {
         self.target = target
         self.selector = selector
@@ -84,24 +33,10 @@ public final class Users<Target: UsersTarget>: GRPCConcreteService {
 // MARK: - User Creation Operations
 
 extension Users where Target: UserCreatable {
-    /// Creates a new user account in the KurrentDB system.
-    ///
-    /// Creates a new user with the specified credentials, profile information, and group memberships.
-    /// After successful creation, the user's details are retrieved and returned.
-    ///
-    /// ## Group Membership
-    ///
-    /// Users can be assigned to built-in or custom groups:
-    /// - **$admins**: Full administrative privileges
-    /// - **$ops**: Operational tasks (scavenges, shutdowns)
-    /// - **Custom groups**: Application-defined access control groups
-    ///
-    /// ## Example
+    /// Creates a new user account and returns the resulting user details.
     ///
     /// ```swift
-    /// let allUsers = Users(target: .all, selector: selector, ...)
-    ///
-    /// let newUser = try await allUsers.create(
+    /// let user = try await client.users.create(
     ///     loginName: "jane_doe",
     ///     password: "secure_password_123",
     ///     fullName: "Jane Doe",
@@ -110,14 +45,12 @@ extension Users where Target: UserCreatable {
     /// ```
     ///
     /// - Parameters:
-    ///   - loginName: Unique username for the new account. Must not already exist.
-    ///   - password: Password for the account. Should meet complexity requirements.
+    ///   - loginName: Unique login name for the new account.
+    ///   - password: Password for the account.
     ///   - fullName: Full display name for the user.
-    ///   - groups: List of group names to assign the user to.
-    ///
-    /// - Returns: The created user's details if successful, or `nil` if retrieval fails.
-    ///
-    /// - Throws: `KurrentError.alreadyExists` if a user with the login name already exists.
+    ///   - groups: Group memberships to assign to the user.
+    /// - Returns: The newly created user's details, or `nil` if retrieval fails.
+    /// - Throws: `KurrentError.alreadyExists` if the login name is already taken.
     ///   `KurrentError.accessDenied` if the caller lacks user creation permissions.
     ///   `KurrentError.invalidArgument` if the login name or password is invalid.
     public func create(loginName: String, password: String, fullName: String, groups: [UserGroup]) async throws(KurrentError) -> UserDetails? {
@@ -135,19 +68,15 @@ extension Users where Target: UserCreatable {
         }
     }
 
-    /// Creates a new user account with variadic group parameters.
-    ///
-    /// Convenience overload that accepts groups as variadic parameters instead of an array.
+    /// Creates a new user account using variadic group parameters.
     ///
     /// - Parameters:
-    ///   - loginName: Unique username for the new account.
+    ///   - loginName: Unique login name for the new account.
     ///   - password: Password for the account.
     ///   - fullName: Full display name for the user.
-    ///   - groups: Variadic list of group names to assign the user to.
-    ///
-    /// - Returns: The created user's details if successful, or `nil` if retrieval fails.
-    ///
-    /// - Throws: `KurrentError.alreadyExists`, `KurrentError.accessDenied`, `KurrentError.invalidArgument`
+    ///   - groups: Variadic group memberships to assign to the user.
+    /// - Returns: The newly created user's details, or `nil` if retrieval fails.
+    /// - Throws: `KurrentError.alreadyExists`, `KurrentError.accessDenied`, `KurrentError.invalidArgument`.
     public func create(loginName: String, password: String, fullName: String, groups: UserGroup...) async throws(KurrentError) -> UserDetails? {
         try await create(loginName: loginName, password: password, fullName: fullName, groups: groups)
     }
@@ -156,44 +85,17 @@ extension Users where Target: UserCreatable {
 // MARK: - User Control Operations
 
 extension Users where Target: UserControllable {
-    /// Retrieves detailed information about the target user.
+    /// Retrieves details for the target user as an asynchronous stream.
     ///
-    /// Returns comprehensive information about the user including login name, full name,
-    /// group memberships, and account status.
-    ///
-    /// ## Example
-    ///
-    /// ```swift
-    /// let users = Users(target: .user("john_doe"), selector: selector, ...)
-    ///
-    /// let detailsStream = try await users.details()
-    /// for try await userDetail in detailsStream {
-    ///     print("User: \(userDetail.loginName)")
-    ///     print("Full name: \(userDetail.fullName)")
-    ///     print("Groups: \(userDetail.groups)")
-    /// }
-    /// ```
-    ///
-    /// - Returns: An asynchronous stream of `UserDetails` values.
-    ///
+    /// - Returns: An async stream of `UserDetails` values for the target user.
     /// - Throws: `KurrentError.notFound` if the user does not exist.
-    ///   `KurrentError.accessDenied` if the caller lacks permissions to view user details.
+    ///   `KurrentError.accessDenied` if the caller lacks permission to view user details.
     public func details() async throws(KurrentError) -> AsyncThrowingStream<UserDetails, Error> {
         let usecase = Details(loginName: target.loginName)
         return try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Enables the target user account, allowing authentication and access.
-    ///
-    /// Enables a previously disabled user account, restoring the user's ability to authenticate
-    /// and access the system according to their assigned permissions.
-    ///
-    /// ## Example
-    ///
-    /// ```swift
-    /// let users = Users(target: .user("john_doe"), selector: selector, ...)
-    /// try await users.enable()
-    /// ```
+    /// Enables the target user account, restoring authentication access.
     ///
     /// - Throws: `KurrentError.notFound` if the user does not exist.
     ///   `KurrentError.accessDenied` if the caller lacks user management permissions.
@@ -202,17 +104,7 @@ extension Users where Target: UserControllable {
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Disables the target user account, preventing authentication and access.
-    ///
-    /// Disables a user account, immediately revoking the user's ability to authenticate.
-    /// The account remains in the system but cannot be used until re-enabled.
-    ///
-    /// ## Example
-    ///
-    /// ```swift
-    /// let users = Users(target: .user("john_doe"), selector: selector, ...)
-    /// try await users.disable()
-    /// ```
+    /// Disables the target user account, preventing authentication.
     ///
     /// - Throws: `KurrentError.notFound` if the user does not exist.
     ///   `KurrentError.accessDenied` if the caller lacks user management permissions.
@@ -221,15 +113,11 @@ extension Users where Target: UserControllable {
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
     }
 
-    /// Updates the target user's information with the specified options.
-    ///
-    /// Updates user profile information such as full name and group memberships. Requires
-    /// the user's current password for authentication.
+    /// Updates the target user's profile with the specified options.
     ///
     /// - Parameters:
-    ///   - password: The user's current password for authentication.
-    ///   - options: Update options specifying which fields to modify.
-    ///
+    ///   - password: Current password for authentication.
+    ///   - options: Options specifying which profile fields to modify.
     /// - Throws: `KurrentError.notFound` if the user does not exist.
     ///   `KurrentError.accessDenied` if authentication fails or permissions are insufficient.
     ///   `KurrentError.invalidArgument` if the update options are invalid.
@@ -240,48 +128,23 @@ extension Users where Target: UserControllable {
 
     /// Updates the target user's full name.
     ///
-    /// Convenience method to update only the user's full name.
-    ///
-    /// ## Example
-    ///
-    /// ```swift
-    /// let users = Users(target: .user("john_doe"), selector: selector, ...)
-    /// try await users.update(fullName: "John Smith", with: "currentPassword")
-    /// ```
-    ///
     /// - Parameters:
     ///   - fullName: The new full name for the user.
-    ///   - password: The user's current password for authentication.
-    ///
-    /// - Throws: `KurrentError.notFound`, `KurrentError.accessDenied`, `KurrentError.invalidArgument`
+    ///   - password: Current password for authentication.
+    /// - Throws: `KurrentError.notFound`, `KurrentError.accessDenied`, `KurrentError.invalidArgument`.
     public func update(fullName: String, with password: String) async throws(KurrentError) {
         let options = Update.Options().set(fullName: fullName)
         try await update(password: password, options: options)
     }
 
-    /// Changes the target user's password.
-    ///
-    /// Updates the user's password after verifying the current password. This operation
-    /// requires knowledge of the current password and is typically used for user-initiated
-    /// password changes.
-    ///
-    /// ## Example
-    ///
-    /// ```swift
-    /// let users = Users(target: .user("john_doe"), selector: selector, ...)
-    /// try await users.change(
-    ///     password: "new_secure_password",
-    ///     origin: "old_password"
-    /// )
-    /// ```
+    /// Changes the target user's password after verifying the current one.
     ///
     /// - Parameters:
     ///   - newPassword: The new password to set.
-    ///   - currentPassword: The user's current password for verification.
-    ///
+    ///   - currentPassword: Current password for verification.
     /// - Throws: `KurrentError.notFound` if the user does not exist.
     ///   `KurrentError.accessDenied` if the current password is incorrect.
-    ///   `KurrentError.invalidArgument` if the new password doesn't meet requirements.
+    ///   `KurrentError.invalidArgument` if the new password does not meet requirements.
     public func change(password newPassword: String, origin currentPassword: String) async throws(KurrentError) {
         let usecase = ChangePassword(loginName: target.loginName, currentPassword: currentPassword, newPassword: newPassword)
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)
@@ -289,22 +152,10 @@ extension Users where Target: UserControllable {
 
     /// Resets the target user's password without requiring the current password.
     ///
-    /// Administrative operation to reset a user's password without knowledge of the current
-    /// password. This requires administrative privileges and is typically used when a user
-    /// has forgotten their password or for account recovery.
-    ///
-    /// ## Example
-    ///
-    /// ```swift
-    /// let users = Users(target: .user("john_doe"), selector: selector, ...)
-    /// try await users.reset(password: "temporary_password_123")
-    /// ```
-    ///
     /// - Parameter newPassword: The new password to set for the user.
-    ///
     /// - Throws: `KurrentError.notFound` if the user does not exist.
     ///   `KurrentError.accessDenied` if the caller lacks administrative permissions.
-    ///   `KurrentError.invalidArgument` if the new password doesn't meet requirements.
+    ///   `KurrentError.invalidArgument` if the new password does not meet requirements.
     public func reset(password newPassword: String) async throws(KurrentError) {
         let usecase = ResetPassword(loginName: target.loginName, newPassword: newPassword)
         _ = try await usecase.perform(selector: selector, callOptions: callOptions)

--- a/docs/superpowers/plans/2026-04-23-api-docs-update.md
+++ b/docs/superpowers/plans/2026-04-23-api-docs-update.md
@@ -1,0 +1,602 @@
+# API Documentation Update Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite all `public` API doc comments in `Sources/KurrentDB/` to be accurate, concise, and consistently styled.
+
+**Architecture:** Nine independent tasks, one per module boundary, executed in parallel. Each task reads its files, rewrites only doc comments (no logic/signature changes), and writes back. A final build verification task runs after all nine complete.
+
+**Tech Stack:** Swift 6, `swift build` for verification, no test changes required.
+
+---
+
+## Documentation Style Reference
+
+Apply this style to every public symbol:
+
+```swift
+/// One-line summary sentence ending with a period.
+///
+/// Optional second paragraph only if the summary alone is ambiguous — 1–2 sentences max.
+///
+/// ```swift
+/// // Code example for factory methods, builder patterns, and non-obvious usage only
+/// ```
+///
+/// - Parameters:
+///   - name: Description.
+/// - Returns: Description.
+/// - Throws: `KurrentError` cases that can be raised.
+```
+
+**Rules (non-negotiable):**
+- Start with noun or verb — never "This is a..." or "A type that..."
+- **Target types and namespace types**: one-line summary only, no parameter/return sections
+- **Enum cases**: inline one-liner `/// Description.`
+- **Properties**: one-line `/// Description.`
+- **Code examples**: add for factory methods, builder patterns, non-obvious usage; omit for simple properties/cases
+- `EventData` is still supported — do NOT add `@available(*, deprecated)`
+- Touch ONLY doc comments — no logic, signature, or access-control changes
+
+---
+
+## Task 1: Core/Config
+
+**Files to modify:**
+- `Sources/KurrentDB/Core/ClientSettings/ClientSettings.swift`
+- `Sources/KurrentDB/Core/ClientSettings/Endpoint.swift`
+- `Sources/KurrentDB/Core/ClientSettings/Authentication.swift`
+- `Sources/KurrentDB/Core/ClientSettings/KeepAlive.swift`
+- `Sources/KurrentDB/Core/ClientSettings/NodePreference.swift`
+- `Sources/KurrentDB/Core/ClientSettings/TopologyClusterMode.swift`
+- `Sources/KurrentDB/Core/RetryPolicy.swift`
+
+- [ ] **Step 1: Read all files**
+
+Read each file listed above in full to understand every public symbol's current doc comment and actual behavior.
+
+- [ ] **Step 2: Rewrite doc comments — ClientSettings.swift**
+
+Cover: type summary, all `public` properties (one-liners), all `public` init/factory methods (`localhost()`, `remote()`, `parse(connectionString:)`, `parseCertificate(path:)`) with parameters/returns/throws, all builder methods with parameter docs. Add a code example on `localhost()` and `parse(connectionString:)`. Remove any prose that no longer matches current fields.
+
+- [ ] **Step 3: Rewrite doc comments — Endpoint.swift**
+
+Cover: type summary, `host`/`port`/`isLocalhost` properties, all inits, `target` property. Add a code example showing string literal usage.
+
+- [ ] **Step 4: Rewrite doc comments — Authentication.swift**
+
+Cover: enum summary, both cases (`credentials`, `x509`) with inline one-liners.
+
+- [ ] **Step 5: Rewrite doc comments — KeepAlive.swift**
+
+Cover: struct summary, `default` static, both inits with parameter docs.
+
+- [ ] **Step 6: Rewrite doc comments — NodePreference.swift**
+
+Cover: enum summary, all four cases (`leader`, `follower`, `random`, `readOnlyReplica`) with inline one-liners.
+
+- [ ] **Step 7: Rewrite doc comments — TopologyClusterMode.swift**
+
+Cover: enum summary, all three cases (`standalone`, `dns`, `seeds`) with inline one-liners.
+
+- [ ] **Step 8: Rewrite doc comments — RetryPolicy.swift**
+
+Cover: struct summary, all properties (one-liners), `JitterStrategy` enum and its cases, `default` static, init with parameter docs.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/KurrentDB/Core/ClientSettings/ClientSettings.swift \
+        Sources/KurrentDB/Core/ClientSettings/Endpoint.swift \
+        Sources/KurrentDB/Core/ClientSettings/Authentication.swift \
+        Sources/KurrentDB/Core/ClientSettings/KeepAlive.swift \
+        Sources/KurrentDB/Core/ClientSettings/NodePreference.swift \
+        Sources/KurrentDB/Core/ClientSettings/TopologyClusterMode.swift \
+        Sources/KurrentDB/Core/RetryPolicy.swift
+git commit -m "[DOCS] Update doc comments for Core/Config types"
+```
+
+---
+
+## Task 2: Core/Types
+
+**Files to modify:**
+- `Sources/KurrentDB/Core/Direction.swift`
+- `Sources/KurrentDB/Core/TimeSpan.swift`
+- `Sources/KurrentDB/Core/UUIDOption.swift`
+- `Sources/KurrentDB/Core/Stream/StreamIdentifier.swift`
+- `Sources/KurrentDB/Core/Stream/StreamPosition.swift`
+- `Sources/KurrentDB/Core/Stream/StreamRevisionRule.swift`
+- `Sources/KurrentDB/Core/Stream/StreamMetadata.swift`
+- `Sources/KurrentDB/Core/Stream/StreamSelector.swift`
+- `Sources/KurrentDB/Core/SubscriptionFilter.swift`
+- `Sources/KurrentDB/Core/Cursor/PositionCursor.swift`
+- `Sources/KurrentDB/Core/Cursor/RevisionCursor.swift`
+- `Sources/KurrentDB/Core/Event/ContentType.swift`
+
+- [ ] **Step 1: Read all files**
+
+Read each file listed above in full.
+
+- [ ] **Step 2: Rewrite doc comments — Direction.swift, TimeSpan.swift, UUIDOption.swift, ContentType.swift**
+
+Each is a small enum. Cover: enum summary, all cases with inline one-liners.
+
+- [ ] **Step 3: Rewrite doc comments — StreamIdentifier.swift**
+
+Cover: struct summary, `name`/`encoding`/`category` properties, `all` static, both inits, `ExpressibleByStringLiteral` conformance note. Add a code example showing string literal init.
+
+- [ ] **Step 4: Rewrite doc comments — StreamPosition.swift**
+
+Cover: struct summary, `commit`/`prepare` properties, `at(commitPosition:preparePosition:)` factory method.
+
+- [ ] **Step 5: Rewrite doc comments — StreamRevisionRule.swift**
+
+Cover: `StreamRevision` enum summary, all cases (`any`, `noStream`, `streamExists`, `at(_:)`) with inline one-liners.
+
+- [ ] **Step 6: Rewrite doc comments — StreamMetadata.swift**
+
+Cover: struct summary, all properties (one-liners), `Acl` enum and cases, `StreamAcl` struct and its properties, all builder methods with parameter docs.
+
+- [ ] **Step 7: Rewrite doc comments — StreamSelector.swift**
+
+Cover: enum summary, both cases (`all`, `specified`) with inline one-liners.
+
+- [ ] **Step 8: Rewrite doc comments — SubscriptionFilter.swift**
+
+Cover: struct summary, `Window` enum and cases, `FilterType` enum and cases, all properties, all builder methods, all static factory methods with parameter docs. Add a code example for `onStreamName(prefix:)` and `onEventType(regex:)`.
+
+- [ ] **Step 9: Rewrite doc comments — PositionCursor.swift, RevisionCursor.swift**
+
+Cover each: enum summary, all cases with inline one-liners, static factory helpers with return docs.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Sources/KurrentDB/Core/Direction.swift \
+        Sources/KurrentDB/Core/TimeSpan.swift \
+        Sources/KurrentDB/Core/UUIDOption.swift \
+        Sources/KurrentDB/Core/Stream/StreamIdentifier.swift \
+        Sources/KurrentDB/Core/Stream/StreamPosition.swift \
+        Sources/KurrentDB/Core/Stream/StreamRevisionRule.swift \
+        Sources/KurrentDB/Core/Stream/StreamMetadata.swift \
+        Sources/KurrentDB/Core/Stream/StreamSelector.swift \
+        Sources/KurrentDB/Core/SubscriptionFilter.swift \
+        Sources/KurrentDB/Core/Cursor/PositionCursor.swift \
+        Sources/KurrentDB/Core/Cursor/RevisionCursor.swift \
+        Sources/KurrentDB/Core/Event/ContentType.swift
+git commit -m "[DOCS] Update doc comments for Core/Types"
+```
+
+---
+
+## Task 3: Core/Events
+
+**Files to modify:**
+- `Sources/KurrentDB/Core/Event/EventData.swift`
+- `Sources/KurrentDB/Core/Event/EventRecord.swift`
+- `Sources/KurrentDB/Core/Event/RecordedEvent.swift`
+- `Sources/KurrentDB/Core/Event/ReadEvent.swift`
+- `Sources/KurrentDB/Core/Event/StreamEvent.swift`
+- `Sources/KurrentDB/Core/Event/EventStoreEvent.swift`
+
+- [ ] **Step 1: Read all files**
+
+Read each file listed above in full.
+
+- [ ] **Step 2: Rewrite doc comments — EventStoreEvent.swift**
+
+Cover: protocol summary, all associated requirements.
+
+- [ ] **Step 3: Rewrite doc comments — EventData.swift**
+
+Cover: struct summary (do NOT add `@available(*, deprecated)` — it is still supported), `Payload` enum and cases, all properties, all `init` overloads with parameter docs. Add a code example for the primary init.
+
+- [ ] **Step 4: Rewrite doc comments — EventRecord.swift**
+
+Cover: struct summary, `Payload` enum and cases, `Schema` struct and its properties, `Schema.Format` enum and all cases, all properties, all inits with parameter/throws docs, all builder methods. Add a code example for creating a JSON record.
+
+- [ ] **Step 5: Rewrite doc comments — RecordedEvent.swift**
+
+Cover: struct summary, all properties (one-liners), `decode(to:)` method with parameter/returns/throws docs.
+
+- [ ] **Step 6: Rewrite doc comments — ReadEvent.swift**
+
+Cover: struct summary, all properties (one-liners), `noPosition` computed property.
+
+- [ ] **Step 7: Rewrite doc comments — StreamEvent.swift**
+
+Cover: struct summary, all properties, all inits with parameter docs. Add a code example showing construction.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/KurrentDB/Core/Event/EventData.swift \
+        Sources/KurrentDB/Core/Event/EventRecord.swift \
+        Sources/KurrentDB/Core/Event/RecordedEvent.swift \
+        Sources/KurrentDB/Core/Event/ReadEvent.swift \
+        Sources/KurrentDB/Core/Event/StreamEvent.swift \
+        Sources/KurrentDB/Core/Event/EventStoreEvent.swift
+git commit -m "[DOCS] Update doc comments for Core/Events"
+```
+
+---
+
+## Task 4: Core/Error + Client
+
+**Files to modify:**
+- `Sources/KurrentDB/Core/Error/KurrentError.swift`
+- `Sources/KurrentDB/Core/Error/KurrentError+RevisionOption.swift`
+- `Sources/KurrentDB/Core/Error/KurrentError+WrongExpectedVersion.swift`
+- `Sources/KurrentDB/KurrentDBClient.swift`
+- `Sources/KurrentDB/KurrentDBClientProtocol.swift`
+
+- [ ] **Step 1: Read all files**
+
+Read each file listed above in full.
+
+- [ ] **Step 2: Rewrite doc comments — KurrentError.swift**
+
+Cover: enum summary, every case with inline one-liners that accurately describe when each error is thrown. Verify each case description matches actual server/client behavior.
+
+- [ ] **Step 3: Rewrite doc comments — KurrentError+RevisionOption.swift and KurrentError+WrongExpectedVersion.swift**
+
+Cover any public nested types (`ExpectedRevisionOption`, `CurrentRevisionOption`) — enum summaries, all cases with inline one-liners.
+
+- [ ] **Step 4: Rewrite doc comments — KurrentDBClient.swift**
+
+Cover: class summary, all `public` properties (one-liners), `init(settings:numberOfThreads:defaultCallOptions:)` with parameter docs, `shutdown()` with throws doc. Add a code example showing basic client setup.
+
+- [ ] **Step 5: Rewrite doc comments — KurrentDBClientProtocol.swift**
+
+Cover: protocol summary, all factory methods (`streams(of:)`, `streams(specified:)`, `persistentSubscriptions(of:)`, etc.) with parameter/returns docs, all computed properties (`allStreams`, `multiStreams`, `allPersistentSubscriptions`, `users`, `monitoring`) with one-liners. Add a code example showing how factory methods are used.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/KurrentDB/Core/Error/KurrentError.swift \
+        Sources/KurrentDB/Core/Error/KurrentError+RevisionOption.swift \
+        Sources/KurrentDB/Core/Error/KurrentError+WrongExpectedVersion.swift \
+        Sources/KurrentDB/KurrentDBClient.swift \
+        Sources/KurrentDB/KurrentDBClientProtocol.swift
+git commit -m "[DOCS] Update doc comments for KurrentError and client entry points"
+```
+
+---
+
+## Task 5: Streams
+
+**Files to modify:**
+- `Sources/KurrentDB/Streams/Streams.swift`
+- `Sources/KurrentDB/Streams/Streams.ReadResponse.swift`
+- `Sources/KurrentDB/Streams/Streams.Subscription.swift`
+- `Sources/KurrentDB/Streams/Target/StreamsTarget.swift`
+- `Sources/KurrentDB/Streams/Target/SpecifiedStreamTarget.swift`
+- `Sources/KurrentDB/Streams/Target/SpecifiedStream.swift`
+- `Sources/KurrentDB/Streams/Target/ProjectionStream.swift`
+- `Sources/KurrentDB/Streams/Target/AllStreamsTarget.swift`
+- `Sources/KurrentDB/Streams/Target/MultiStreamsTarget.swift`
+- `Sources/KurrentDB/Streams/Target/AnyStreamTarget.swift`
+- `Sources/KurrentDB/Streams/API/Streams+AllStreamsTarget.swift`
+- `Sources/KurrentDB/Streams/API/Streams+SpecifiedStreamTarget.swift`
+- `Sources/KurrentDB/Streams/API/Streams+ProjectionStream.swift`
+- `Sources/KurrentDB/Streams/KurrentDBClient+Streams.swift`
+
+- [ ] **Step 1: Read all files**
+
+Read each file listed above in full.
+
+- [ ] **Step 2: Rewrite doc comments — target types**
+
+For `StreamsTarget`, `SpecifiedStreamTarget`: protocol summaries only (one-liners).
+For `SpecifiedStream`, `ProjectionStream`, `AllStreamsTarget`, `MultiStreamsTarget`, `AnyStreamTarget`: struct/class one-line summaries only.
+
+- [ ] **Step 3: Rewrite doc comments — Streams.swift**
+
+Cover: class summary, `target` property. Add a code example showing how `Streams` is obtained via the client.
+
+- [ ] **Step 4: Rewrite doc comments — Streams.ReadResponse.swift**
+
+Cover: enum summary, both cases with inline one-liners, `event` computed property with returns/throws docs.
+
+- [ ] **Step 5: Rewrite doc comments — Streams.Subscription.swift**
+
+Cover: struct summary, `events` property, `subscriptionId` property, `cancel()` method.
+
+- [ ] **Step 6: Rewrite doc comments — API extension files**
+
+For `Streams+SpecifiedStreamTarget.swift`: cover `append`, `read`, `subscribe`, `delete`, `tombstone`, `setMetadata`, `getMetadata` methods — each with parameter/returns/throws docs. Add code examples for `append` and `read`.
+For `Streams+AllStreamsTarget.swift`: cover `read`, `subscribe` methods with parameter/returns/throws docs.
+For `Streams+ProjectionStream.swift`: cover its public methods with parameter/returns/throws docs.
+
+- [ ] **Step 7: Rewrite doc comments — KurrentDBClient+Streams.swift**
+
+Cover all `streams(of:)` / `streams(specified:)` factory methods with parameter/returns docs.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/KurrentDB/Streams/Streams.swift \
+        Sources/KurrentDB/Streams/Streams.ReadResponse.swift \
+        Sources/KurrentDB/Streams/Streams.Subscription.swift \
+        Sources/KurrentDB/Streams/Target/ \
+        Sources/KurrentDB/Streams/API/ \
+        Sources/KurrentDB/Streams/KurrentDBClient+Streams.swift
+git commit -m "[DOCS] Update doc comments for Streams module"
+```
+
+---
+
+## Task 6: Projections
+
+**Files to modify:**
+- `Sources/KurrentDB/Core/Projection/Projection.swift`
+- `Sources/KurrentDB/Core/Projection/Projection.Detail.swift`
+- `Sources/KurrentDB/Core/Projection/Projection.Mode.swift`
+- `Sources/KurrentDB/Core/Projection/Projection.Status.swift`
+- `Sources/KurrentDB/Projections/Projections.swift`
+- `Sources/KurrentDB/Projections/Target/ProjectionsTarget.swift`
+- `Sources/KurrentDB/Projections/Target/ProjectionControlable.swift`
+- `Sources/KurrentDB/Projections/Target/NameTarget.swift`
+- `Sources/KurrentDB/Projections/Target/SpecifiedContinuousProjectionTarget.swift`
+- `Sources/KurrentDB/Projections/Target/SpecifiedTransientProjectionTarget.swift`
+- `Sources/KurrentDB/Projections/Target/UnspecifiedContinuousProjectionTarget.swift`
+- `Sources/KurrentDB/Projections/Target/UnspecifiedTransientProjectionTarget.swift`
+- `Sources/KurrentDB/Projections/Target/OneTimeProjectionTarget.swift`
+- `Sources/KurrentDB/Projections/Target/AnyProjectionsTarget.swift`
+- `Sources/KurrentDB/Projections/API/Projections+AnyMode.swift`
+- `Sources/KurrentDB/Projections/API/Projections+ContinuousMode.swift`
+- `Sources/KurrentDB/Projections/API/Projections+OneTimeMode.swift`
+- `Sources/KurrentDB/Projections/API/Projections+TransientMode.swift`
+- `Sources/KurrentDB/Projections/KurrentDBClient+Projections.swift`
+
+- [ ] **Step 1: Read all files**
+
+Read each file listed above in full.
+
+- [ ] **Step 2: Rewrite doc comments — Projection namespace types**
+
+`Projection.swift`: namespace summary. `Projection.Detail`: struct summary + all public properties as one-liners. `Projection.Mode`: enum summary + all cases with inline one-liners. `Projection.Status`: enum summary + all cases with inline one-liners.
+
+- [ ] **Step 3: Rewrite doc comments — target types**
+
+`ProjectionsTarget`, `ProjectionControlable`: protocol one-line summaries.
+All concrete target structs (`NameTarget`, `SpecifiedContinuousProjectionTarget`, etc.): one-line summaries only.
+
+- [ ] **Step 4: Rewrite doc comments — Projections.swift**
+
+Cover: class summary, `target` property. Add a code example showing how `Projections` is obtained via the client.
+
+- [ ] **Step 5: Rewrite doc comments — API extension files**
+
+For each of `Projections+ContinuousMode.swift`, `Projections+TransientMode.swift`, `Projections+OneTimeMode.swift`, `Projections+AnyMode.swift`: cover all public methods (`enable`, `disable`, `abort`, `reset`, `delete`, `update`, `detail`, `result`, `state`, `create`) with parameter/returns/throws docs. Add a code example for `create` in the continuous mode file.
+
+- [ ] **Step 6: Rewrite doc comments — KurrentDBClient+Projections.swift**
+
+Cover all factory methods with parameter/returns docs.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/KurrentDB/Core/Projection/ \
+        Sources/KurrentDB/Projections/Projections.swift \
+        Sources/KurrentDB/Projections/Target/ \
+        Sources/KurrentDB/Projections/API/ \
+        Sources/KurrentDB/Projections/KurrentDBClient+Projections.swift
+git commit -m "[DOCS] Update doc comments for Projections module"
+```
+
+---
+
+## Task 7: PersistentSubscriptions
+
+**Files to modify:**
+- `Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.swift`
+- `Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.Settings.swift`
+- `Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.SystemConsumerStrategy.swift`
+- `Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.StreamSelection.swift`
+- `Sources/KurrentDB/Core/PersistenSubscription/PersistenSubscription.EventResult.swift`
+- `Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.ConnectionInfo.swift`
+- `Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.Measurement.swift`
+- `Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.SubscriptionInfo.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.ReadResponse.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.StreamSelection.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptionStreamSelection.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptionsSettingsBuildable.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/Target/PersistentSubscriptionTarget.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/Target/SpecifiedPersistentSubscriptionTarget.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/Target/AllStreamPersistentSubscriptionTarget.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/Target/AllPersistentSubscriptionTarget.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/Target/FilterStreamPersistentSubscriptionTarget.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/Target/AnyPersistentSubscriptionTarget.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+All.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+AllStream.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+FilterStream.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/API/PersistentSubscriptions+Specified.swift`
+- `Sources/KurrentDB/PersistentSubscriptions/KurrentDBClient+PersistentSubscriptions.swift`
+
+- [ ] **Step 1: Read all files**
+
+Read each file listed above in full.
+
+- [ ] **Step 2: Rewrite doc comments — Core PersistentSubscription types**
+
+`PersistentSubscription.swift`: namespace summary.
+`PersistentSubscription.Settings`: struct summary + all public properties as one-liners + builder methods with parameter docs.
+`PersistentSubscription.SystemConsumerStrategy`: enum summary + all cases with inline one-liners.
+`PersistentSubscription.StreamSelection`, `EventResult`, `ConnectionInfo`, `Measurement`, `SubscriptionInfo`: each type summary + all public properties as one-liners.
+
+- [ ] **Step 3: Rewrite doc comments — target types**
+
+`PersistentSubscriptionTarget` protocol: one-line summary.
+All concrete targets (`SpecifiedPersistentSubscriptionTarget`, `AllStreamPersistentSubscriptionTarget`, etc.): one-line summaries only.
+`PersistentSubscriptionStreamSelection` protocol and conforming types: one-line summaries.
+
+- [ ] **Step 4: Rewrite doc comments — PersistentSubscriptions.swift, ReadResponse, Subscription, StreamSelection**
+
+`PersistentSubscriptions.swift`: class summary, `target` property.
+`ReadResponse`: enum summary, all cases with inline one-liners, computed property with returns/throws.
+`Subscription`: struct summary, all properties, `cancel()` / `ack()` / `nack()` methods with parameter/throws docs.
+`StreamSelection`: type summary + properties.
+`PersistentSubscriptionsSettingsBuildable`: protocol summary.
+
+- [ ] **Step 5: Rewrite doc comments — API extension files**
+
+For each of `PersistentSubscriptions+Specified.swift`, `PersistentSubscriptions+AllStream.swift`, `PersistentSubscriptions+FilterStream.swift`, `PersistentSubscriptions+All.swift`: cover all public methods (`create`, `update`, `delete`, `subscribe`, `getInfo`, `list`, `replayParked`) with parameter/returns/throws docs. Add a code example for `subscribe` in the Specified file.
+
+- [ ] **Step 6: Rewrite doc comments — KurrentDBClient+PersistentSubscriptions.swift**
+
+Cover all factory methods with parameter/returns docs.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/KurrentDB/Core/PersistenSubscription/ \
+        Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.swift \
+        Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.ReadResponse.swift \
+        Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.Subscription.swift \
+        Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.StreamSelection.swift \
+        Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptionStreamSelection.swift \
+        Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptionsSettingsBuildable.swift \
+        Sources/KurrentDB/PersistentSubscriptions/Target/ \
+        Sources/KurrentDB/PersistentSubscriptions/API/ \
+        Sources/KurrentDB/PersistentSubscriptions/KurrentDBClient+PersistentSubscriptions.swift
+git commit -m "[DOCS] Update doc comments for PersistentSubscriptions module"
+```
+
+---
+
+## Task 8: Users + Operations + Monitoring
+
+**Files to modify:**
+- `Sources/KurrentDB/Users/Users.swift`
+- `Sources/KurrentDB/Users/UserDetails.swift`
+- `Sources/KurrentDB/Users/UserGroup.swift`
+- `Sources/KurrentDB/Users/Target/UsersTarget.swift`
+- `Sources/KurrentDB/Users/Target/UserCreatable.swift`
+- `Sources/KurrentDB/Users/Target/UserControllable.swift`
+- `Sources/KurrentDB/Users/Target/AllUsersTarget.swift`
+- `Sources/KurrentDB/Users/Target/SpecifiedUserTarget.swift`
+- `Sources/KurrentDB/Users/KurrentDBClient+Users.swift`
+- `Sources/KurrentDB/Operations/Operations.swift`
+- `Sources/KurrentDB/Operations/OperationsTarget.swift`
+- `Sources/KurrentDB/Operations/ScavengeResponse.swift`
+- `Sources/KurrentDB/Operations/Protocols/NodeControllable.swift`
+- `Sources/KurrentDB/Operations/Protocols/ScavengeControllable.swift`
+- `Sources/KurrentDB/Operations/Protocols/ScavengeCreatable.swift`
+- `Sources/KurrentDB/Operations/Protocols/SystemControllable.swift`
+- `Sources/KurrentDB/Operations/Targets/ActiveScavenge.swift`
+- `Sources/KurrentDB/Operations/Targets/NodeOperations.swift`
+- `Sources/KurrentDB/Operations/Targets/ScavengeOperations.swift`
+- `Sources/KurrentDB/Operations/Targets/SystemOperations.swift`
+- `Sources/KurrentDB/Operations/KurrentDBClient+ServerOperations.swift`
+- `Sources/KurrentDB/Monitoring/Monitoring.swift`
+- `Sources/KurrentDB/Monitoring/KurrentDBClient+Monitoring.swift`
+
+- [ ] **Step 1: Read all files**
+
+Read each file listed above in full.
+
+- [ ] **Step 2: Rewrite doc comments — Users types**
+
+`UsersTarget`, `UserCreatable`, `UserControllable` protocols: one-line summaries.
+`AllUsersTarget`, `SpecifiedUserTarget` structs: one-line summaries.
+`UserDetails`: struct summary + all properties as one-liners + init parameter docs.
+`UserGroup`: enum summary + all cases with inline one-liners + `rawValue` + `init(rawValue:)` docs. Add a code example showing string literal usage.
+`Users.swift`: class summary + `target` property.
+`KurrentDBClient+Users.swift`: factory method docs.
+Extension methods (`create`, `details`, `enable`, `disable`, `update`, `changePassword`, `resetPassword`): full parameter/returns/throws docs.
+
+- [ ] **Step 3: Rewrite doc comments — Operations types**
+
+`OperationsTarget` protocol and all sub-protocols (`ScavengeCreatable`, `ScavengeControllable`, `NodeControllable`, `SystemControllable`): one-line summaries.
+`ScavengeOperations`, `ActiveScavenge`, `NodeOperations`, `SystemOperations` targets: one-line summaries.
+`Operations.swift`: class summary + `target` property.
+`OperationsTarget.swift` file (if it has extension methods): parameter/returns/throws docs.
+`ScavengeResponse`: struct/enum summary + all properties/cases.
+`KurrentDBClient+ServerOperations.swift`: factory method docs.
+
+- [ ] **Step 4: Rewrite doc comments — Monitoring**
+
+`Monitoring.swift`: class summary, `stats(useMetadata:refreshTimePeriodInMs:)` method with parameter/returns/throws docs.
+`KurrentDBClient+Monitoring.swift`: factory method docs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/KurrentDB/Users/ \
+        Sources/KurrentDB/Operations/ \
+        Sources/KurrentDB/Monitoring/
+git commit -m "[DOCS] Update doc comments for Users, Operations, and Monitoring modules"
+```
+
+---
+
+## Task 9: Gossip + NodeSelector
+
+**Files to modify:**
+- `Sources/KurrentDB/Gossip/Gossip.swift`
+- `Sources/KurrentDB/Gossip/MemberInfo.swift`
+- `Sources/KurrentDB/Gossip/VNodeState.swift`
+- `Sources/KurrentDB/Gossip/KurrentDBClient+Gossip.swift`
+- `Sources/KurrentDB/Core/NodeSelector.swift`
+
+- [ ] **Step 1: Read all files**
+
+Read each file listed above in full.
+
+- [ ] **Step 2: Rewrite doc comments — VNodeState.swift**
+
+Enum summary + all 16 cases with accurate inline one-liners describing each node state in the Kurrent cluster lifecycle.
+
+- [ ] **Step 3: Rewrite doc comments — MemberInfo.swift**
+
+Struct summary + all public properties (`instanceId`, `timeStamp`, `state`, `isAlive`, `httpEndPoint`) as one-liners.
+
+- [ ] **Step 4: Rewrite doc comments — Gossip.swift**
+
+Class summary, `read(timeout:notAllowedStates:)` method with parameter/returns/throws docs.
+
+- [ ] **Step 5: Rewrite doc comments — KurrentDBClient+Gossip.swift**
+
+Cover the `gossip` factory property/method with returns docs.
+
+- [ ] **Step 6: Rewrite doc comments — NodeSelector.swift**
+
+`NodeSelector` actor summary, `select()` method with returns/throws docs.
+`NodeDiscover` actor summary (one-liner — internal use), `next()` method docs.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/KurrentDB/Gossip/ \
+        Sources/KurrentDB/Core/NodeSelector.swift
+git commit -m "[DOCS] Update doc comments for Gossip and NodeSelector"
+```
+
+---
+
+## Task 10: Final Build Verification
+
+**Depends on:** Tasks 1–9 all complete.
+
+- [ ] **Step 1: Run swift build**
+
+```bash
+cd /Volumes/Development/swift-kurrentdb && swift build
+```
+
+Expected: build succeeds with no errors or warnings related to documentation.
+
+- [ ] **Step 2: If build fails, fix compilation errors only**
+
+Doc comment changes should never break the build. If errors appear, check that no signatures were accidentally modified. Fix only what is needed to restore a clean build.
+
+- [ ] **Step 3: Commit fix if needed**
+
+```bash
+git add <affected files>
+git commit -m "[DOCS] Fix build issues after documentation update"
+```

--- a/docs/superpowers/specs/2026-04-23-api-docs-design.md
+++ b/docs/superpowers/specs/2026-04-23-api-docs-design.md
@@ -1,0 +1,70 @@
+# API Documentation Update — Design Spec
+**Date:** 2026-04-23  
+**Scope:** All `public` symbols in `Sources/KurrentDB/` and `Sources/GRPCEncapsulates/`
+
+---
+
+## Goal
+
+Rewrite all public API doc comments to be accurate, consistent, and concise. Many existing descriptions reflect an older API shape and need to be corrected. All symbols — even previously undocumented ones — receive coverage.
+
+---
+
+## Documentation Style
+
+```swift
+/// One-line summary sentence ending with a period.
+///
+/// Optional second paragraph only if the summary alone is ambiguous — 1–2 sentences max.
+///
+/// ```swift
+/// // Code example for factory methods, builder patterns, and non-obvious usage only
+/// ```
+///
+/// - Parameters:
+///   - name: Description.
+/// - Returns: Description.
+/// - Throws: `KurrentError` cases that can be raised.
+```
+
+### Rules
+
+- Start directly with noun or verb — no "This is a..." or "A type that..." filler
+- **Target types and namespace types**: one-line summary only, no parameter/return sections
+- **Enum cases**: inline one-liner `/// Description.`
+- **Properties**: one-line `/// Description.`
+- **Code examples**: add for factory methods, builder patterns, and non-obvious usage; omit for simple properties and enum cases
+- No changes outside doc comments — logic, signatures, and access control are untouched
+- `EventData` is still supported and public; do not add `@available(*, deprecated)`
+
+---
+
+## Execution Strategy
+
+Nine parallel subagents, each responsible for one module boundary:
+
+| Subagent | Scope |
+|---|---|
+| 1. Core/Config | `ClientSettings`, `Endpoint`, `Authentication`, `KeepAlive`, `NodePreference`, `TopologyClusterMode`, `OperationRetryPolicy` |
+| 2. Core/Types | `Direction`, `TimeSpan`, `UUIDOption`, `StreamIdentifier`, `StreamPosition`, `StreamRevision`, `StreamMetadata`, `StreamSelector`, `SubscriptionFilter`, `PositionCursor`, `RevisionCursor`, `ContentType` |
+| 3. Core/Events | `EventData`, `EventRecord`, `RecordedEvent`, `ReadEvent`, `StreamEvent` |
+| 4. Core/Error + Client | `KurrentError`, `KurrentDBClient`, `KurrentDBClientProtocol` |
+| 5. Streams | `Streams<Target>`, `ReadResponse`, `Subscription`, all stream target types |
+| 6. Projections | `Projections<Target>`, `Projection` namespace, all projection target types |
+| 7. PersistentSubscriptions | `PersistentSubscriptions<Target>`, all subscription target types |
+| 8. Users + Operations + Monitoring | `Users<Target>`, `UserDetails`, `UserGroup`, `Operations<Target>`, `Monitoring`, target types |
+| 9. Gossip + NodeSelector | `Gossip`, `MemberInfo`, `VNodeState`, `NodeSelector`, `NodeDiscover` |
+
+---
+
+## Completion Criteria
+
+Each subagent is done when:
+
+1. Every `public` symbol has a doc comment
+2. Style rules applied consistently throughout
+3. No factually incorrect statements — descriptions match actual current behaviour
+4. Existing correct content rewritten to concise style (no legacy prose left behind)
+5. No changes outside doc comments
+
+After all subagents complete: `swift build` must pass.


### PR DESCRIPTION
## Summary

- Add or rewrite doc comments for all public symbols across the entire `KurrentDB` module
- Follow a consistent style: concise noun/verb summaries, inline one-liners for enum cases and properties, parameter/returns/throws blocks, and code examples on key entry points
- Fix position tracking bug in `Subscription.events` bridge task (`eventResult.position` was incorrectly reading from `tracker.position`)
- Add documentation for new APIs introduced by the Subscription refactor: `lastRevision`, `lastPosition`, `events` lazy-caching behaviour, `SubscriptionEventResult` protocol

## Modules covered

| Commit | Module |
|--------|--------|
| Core/Config | `ClientSettings`, `Endpoint`, `Authentication`, `KeepAlive`, `NodePreference`, `TopologyClusterMode` |
| Core/Types | Cursors, Direction, Stream types, `SubscriptionFilter`, `TimeSpan`, `UUIDOption` |
| Core/Events | `EventData`, `EventRecord`, `ReadEvent`, `RecordedEvent`, `StreamEvent`, `ContentType` |
| KurrentError | Error types and client entry points |
| Streams | All stream targets, usecases, and API extensions |
| Projections | All projection targets, usecases, and API extensions |
| PersistentSubscriptions | `Subscription<EventResult>`, `SubscriptionEventResult`, all targets and usecases |
| Users / Operations / Monitoring | All public types and client methods |
| Gossip / NodeSelector | `VNodeState`, `MemberInfo`, `Gossip`, `NodeSelector` |

## Test plan

- [ ] `swift build` passes
- [ ] Doc comments render correctly in Xcode Quick Help