### PR TITLE
[CI] Add KurrentDB 26.1 to integration test matrix

### DIFF
--- a/.github/workflows/swift-build-testing.yml
+++ b/.github/workflows/swift-build-testing.yml
@@ -19,6 +19,7 @@ jobs:
           - { version: "24.10",  image: "docker.eventstore.com/eventstore/eventstoredb-ee:24.10", compose_file: "server/docker-compose.eventstore.yaml", supports_multi_streams: "false" }
           - { version: "25.1",   image: "docker.eventstore.com/kurrent-latest/kurrentdb:25.1",            compose_file: "server/docker-compose.yaml",             supports_multi_streams: "true"  }
           - { version: "26.0",   image: "docker.eventstore.com/kurrent-latest/kurrentdb:26.0",            compose_file: "server/docker-compose.yaml",             supports_multi_streams: "true"  }
+          - { version: "26.1",   image: "docker.eventstore.com/kurrent-latest/kurrentdb:26.1",            compose_file: "server/docker-compose.yaml",             supports_multi_streams: "true"  }
     runs-on: ${{ matrix.os }}
     env:
       KURRENTDB_SUPPORTS_MULTI_STREAMS: ${{ matrix.kurrentdb.supports_multi_streams }}

--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Streams write-side error paths are explicitly covered:
 
 | Server Version | Status | Notes |
 |:--------------:|:------:|-------|
+| **KurrentDB 26.1** | ✅ Supported | Full feature support |
 | **KurrentDB 26.0** | ✅ Supported | Full feature support |
 | **KurrentDB 25.1** | ✅ Supported | Full feature support |
 | **EventStoreDB 24.x** | ✅ Supported | Core features supported; KurrentDB v2 batch append not available |


### PR DESCRIPTION
## Summary

- Add KurrentDB 26.1 to the `swift-build-testing` job's matrix so the full integration suite (Streams / Projections / PersistentSubscriptions / Users / Monitoring / Gossip / KurrentCore / MockClient) runs against 26.1 on every supported Swift toolchain (6.0 / 6.1 / 6.2 / 6.3). Same registry path (`docker.eventstore.com/kurrent-latest/kurrentdb:26.1`) and same `server/docker-compose.yaml` as 26.0.
- Bump the README **KurrentDB Server Compatibility** table so the published docs match what CI actually verifies.

No changes to the `build-linux-distros` job (it's server-agnostic and only runs `MockClientTests`).

## Test plan

- [ ] CI passes the new `Swift X.Y / KurrentDB 26.1` cells for all four Swift versions.
- [ ] If any cell fails, inspect the cluster logs the workflow dumps on health-check failure before concluding that 26.1 is unsupported — the existing wait-for-healthy step gives 5 minutes, which has been enough for prior versions.