### PR TITLE
[DOCS] Fix Qodo-flagged README examples; move Acknowledgments to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ It's people like you that make swift-kurrentdb a great tool for the Swift commun
 ## 📋 Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
+- [Project Heritage & Design Philosophy](#-project-heritage--design-philosophy)
 - [How Can I Contribute?](#how-can-i-contribute)
 - [Development Setup](#development-setup)
 - [Pull Request Process](#pull-request-process)
@@ -24,6 +25,35 @@ This project and everyone participating in it is governed by our commitment to p
 - Be collaborative and constructive
 - Focus on what is best for the community
 - Show empathy towards other community members
+
+## 🧭 Project Heritage & Design Philosophy
+
+Knowing where the public API comes from — and where it deliberately steps away from precedent — helps when reviewing PRs and proposing new surface. This is the context maintainers use when evaluating design questions.
+
+### Built on
+
+- [grpc-swift](https://github.com/grpc/grpc-swift) — Swift gRPC implementation (v2.x)
+- [swift-nio](https://github.com/apple/swift-nio) — Non-blocking I/O
+- [swift-log](https://github.com/apple/swift-log) — Logging API
+
+### Design influences and divergences
+
+The shape of the public API and the underlying wire semantics owe a lot to the official Kurrent/EventStoreDB clients — primarily the [.NET](https://github.com/EventStore/EventStore-Client-Dotnet), [Java](https://github.com/EventStore/EventStoreDB-Client-Java), and [Node.js](https://github.com/EventStore/EventStoreDB-Client-NodeJS) clients. What was adopted, and where this client deliberately takes a different path:
+
+**Adopted from the official clients**
+- The `esdb://` connection string format, cluster gossip discovery, and `NodePreference` semantics (leader / follower / random) for routing.
+- Optimistic concurrency via expected revision (`.any` / `.noStream` / `.streamExists` / `.at(n)`) and the resulting `wrongExpectedVersion` error path.
+- Persistent subscription ACK/NACK with park/retry/skip/stop semantics.
+- Subscription filtering primitives (event-type / stream-name prefix and regex).
+
+**Where swift-kurrentdb diverges**
+- **Target-based API instead of flat methods.** Official clients expose a flat surface like `client.appendToStream(name, options, events)`. swift-kurrentdb scopes operations through typed targets — `client.streams(of: .specified("orders")).append(...)`, `client.projections(name: ...)`, `client.persistentSubscriptions(stream: ..., group: ...)` — so the compiler rules out illegal operations (e.g. tombstoning `$all`) before they reach the wire.
+- **Trailing-closure builders for options** instead of options objects/records. This keeps the call site terse and removes the need for either parameter overloads or partially-filled structs.
+- **Actor-based client with Swift 6 strict concurrency.** `KurrentDBClient` and `NodeSelector` are actors, not thread-safe instances guarded by locks. The whole package compiles under `-strict-concurrency=complete` with zero `@unchecked Sendable`.
+- **Typed throws.** Operations throw `KurrentError` rather than a hierarchy of untyped exceptions, so callers exhaustively handle failure cases at compile time.
+- **Three-layer module split** (`KurrentDB` → `GRPCEncapsulates` → `Generated`). gRPC patterns (`UnaryUnary`, `UnaryStream`, etc.) live in their own module so the public API stays decoupled from generated protobuf types — the same pattern can be reused by other gRPC-backed Swift clients without dragging KurrentDB-specific types along.
+
+When in doubt about a proposed design, lean toward these principles. If a new surface fights them, that's a signal to discuss the design in an issue before opening a PR.
 
 ## 🎯 How Can I Contribute?
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ let state: CountResult? = try await client.projections(name: "order-count").stat
 let result: Int? = try await client.projections(name: "order-count").result(of: Int.self)
 
 // List
-let continuous = try await client.projections(of: .continuous).list()
-let all = try await client.projections(of: .any).list()
+let continuous = try await client.projections(of: .anyContinuous).list()
+let all = try await client.projections(of: .anyMode).list()
 ```
 
 ### Persistent Subscriptions
@@ -192,7 +192,7 @@ let all = try await client.projections(of: .any).list()
 ```swift
 // Create a subscription group
 try await client.persistentSubscriptions(stream: "orders", group: "order-workers").create {
-    $0.settings.startFrom = .start
+    $0.revision = .start
     $0.settings.maxRetryCount = 5
 }
 
@@ -449,47 +449,6 @@ Contributions are welcome! Whether it's bug reports, feature requests, documenta
 ## License
 
 MIT License — see [LICENSE](Licence) for details.
-
-## Acknowledgments
-
-Built with:
-- [grpc-swift](https://github.com/grpc/grpc-swift) — Swift gRPC implementation (v2.x)
-- [swift-nio](https://github.com/apple/swift-nio) — Non-blocking I/O
-- [swift-log](https://github.com/apple/swift-log) — Logging API
-
-### Design influences and divergences
-
-The shape of the public API and the underlying wire semantics owe a lot to the official
-Kurrent/EventStoreDB clients — primarily the [.NET](https://github.com/EventStore/EventStore-Client-Dotnet),
-[Java](https://github.com/EventStore/EventStoreDB-Client-Java), and
-[Node.js](https://github.com/EventStore/EventStoreDB-Client-NodeJS) clients.
-What was adopted, and where this client deliberately takes a different path:
-
-**Adopted from the official clients**
-- The `esdb://` connection string format, cluster gossip discovery, and `NodePreference`
-  semantics (leader / follower / random) for routing.
-- Optimistic concurrency via expected revision (`.any` / `.noStream` / `.streamExists` / `.at(n)`)
-  and the resulting `wrongExpectedVersion` error path.
-- Persistent subscription ACK/NACK with park/retry/skip/stop semantics.
-- Subscription filtering primitives (event-type / stream-name prefix and regex).
-
-**Where swift-kurrentdb diverges**
-- **Target-based API instead of flat methods.** Official clients expose a flat surface like
-  `client.appendToStream(name, options, events)`. swift-kurrentdb scopes operations through
-  typed targets — `client.streams(of: .specified("orders")).append(...)`,
-  `client.projections(name: ...)`, `client.persistentSubscriptions(stream: ..., group: ...)` —
-  so the compiler rules out illegal operations (e.g. tombstoning `$all`) before they reach the wire.
-- **Trailing-closure builders for options** instead of options objects/records. This keeps the
-  call site terse and removes the need for either parameter overloads or partially-filled structs.
-- **Actor-based client with Swift 6 strict concurrency.** `KurrentDBClient` and `NodeSelector`
-  are actors, not thread-safe instances guarded by locks. The whole package compiles under
-  `-strict-concurrency=complete` with zero `@unchecked Sendable`.
-- **Typed throws.** Operations throw `KurrentError` rather than a hierarchy of untyped
-  exceptions, so callers exhaustively handle failure cases at compile time.
-- **Three-layer module split** (`KurrentDB` → `GRPCEncapsulates` → `Generated`).
-  gRPC patterns (`UnaryUnary`, `UnaryStream`, etc.) live in their own module so the public
-  API stays decoupled from generated protobuf types — the same pattern can be reused by
-  other gRPC-backed Swift clients without dragging KurrentDB-specific types along.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #112. Addresses two correctness bugs Qodo flagged on the merged PR, plus a stylistic cleanup that was sitting in the same vicinity.

### Qodo bugs

Both flagged by qodo-code-review on #112 and verified against the source before fixing.

**1. Persistent subscription create snippet — wrong starting-position field.** The example was using `$0.settings.startFrom = .start`, but `SpecifiedStream.Create.Options.settings` (`PersistentSubscription.CreateSettings`) has no `startFrom` member. The starting position is the **top-level** `Options.revision: RevisionCursor`. Updated to:

\`\`\`swift
try await client.persistentSubscriptions(stream: \"orders\", group: \"order-workers\").create {
    \$0.revision = .start
    \$0.settings.maxRetryCount = 5
}
\`\`\`

(`maxRetryCount` does live on `settings` per \`PersistentSubscription.Settings.swift:21\`, so that line is unchanged.)

**2. Projection list snippet — wrong target factory names.** Was calling `client.projections(of: .continuous).list()` and `client.projections(of: .any).list()`. The actual factories declared in \`Sources/KurrentDB/Projections/Target/\` are:

- \`.anyContinuous\` → \`UnspecifiedContinuousProjectionTarget\` (Projections+ContinuousMode.swift:41)
- \`.anyMode\` → \`AnyProjectionsTarget\` (Projections+AnyMode.swift:15)

Both targets have \`.list()\`. Updated the snippet accordingly.

### Move Acknowledgments out of the README

The Acknowledgments section had grown a multi-paragraph \"Design influences and divergences\" writeup that compares this client to the official .NET / Java / Node.js clients. That content is genuinely useful — for **reviewers and prospective contributors** evaluating PRs against the project's design principles, not for first-time README readers looking to get started. Relocated to **CONTRIBUTING.md** under a new section **\`🧭 Project Heritage & Design Philosophy\`**, placed right after \"Code of Conduct\" so contributors hit it early in their reading flow. The README's \"Built on\" dependency list moved with it.

No content was lost — this is a relocation, not a rewrite. README ends cleanly with License + the existing \"Made by Grady Zhuo\" sign-off.

## Test plan

- [ ] Visually verify the two corrected snippets on the PR's rendered README.
- [ ] Spot-check by pasting the persistent-subscription \`create\` snippet and the two \`list\` snippets into a scratch Swift file with \`import KurrentDB\` and confirming they compile.
- [ ] Confirm CONTRIBUTING.md's new section renders, the TOC link resolves, and no Acknowledgments content was dropped in the move.