### PR TITLE
[ADD] GitHub Pages landing site at /docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>swift-kurrentdb — Type-safe Swift client for Kurrent</title>
+  <meta name="description" content="A modern, type-safe Swift client for Kurrent (formerly EventStoreDB). Built for Server-Side Swift and Event Sourcing with Swift 6 strict concurrency.">
+  <meta property="og:title" content="swift-kurrentdb">
+  <meta property="og:description" content="A modern, type-safe Swift client for Kurrent. Built for Server-Side Swift and Event Sourcing.">
+  <meta property="og:image" content="https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:fikpipzuggbnuqew3treexnn/bafkreiadjakshxna7sn2gtwxdibew7e66vp3xplpghr72sxpwptsq7gf3i@jpeg">
+  <meta property="og:url" content="https://gradyzhuo.github.io/swift-kurrentdb/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" href="https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:fikpipzuggbnuqew3treexnn/bafkreiadjakshxna7sn2gtwxdibew7e66vp3xplpghr72sxpwptsq7gf3i@jpeg">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="hero">
+  <div class="container">
+    <img class="hero-icon" src="https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:fikpipzuggbnuqew3treexnn/bafkreiadjakshxna7sn2gtwxdibew7e66vp3xplpghr72sxpwptsq7gf3i@jpeg" alt="swift-kurrentdb icon">
+    <h1>swift-kurrentdb</h1>
+    <p class="tagline">A modern, type-safe Swift client for Kurrent <span class="dim">(formerly EventStoreDB)</span></p>
+    <p class="tagline-zh">為 Kurrent / EventStoreDB 而設計的現代化 Swift 客戶端</p>
+    <p class="subtagline">Built for Server-Side Swift and Event Sourcing — 為伺服器端 Swift 與 Event Sourcing 打造</p>
+
+    <div class="badges">
+      <a href="https://swiftpackageindex.com/gradyzhuo/swift-kurrentdb"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fgradyzhuo%2Fswift-kurrentdb%2Fbadge%3Ftype%3Dswift-versions" alt="Swift versions"></a>
+      <a href="https://swiftpackageindex.com/gradyzhuo/swift-kurrentdb"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fgradyzhuo%2Fswift-kurrentdb%2Fbadge%3Ftype%3Dplatforms" alt="Platforms"></a>
+      <a href="https://github.com/gradyzhuo/swift-kurrentdb/blob/main/Licence"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+      <a href="https://github.com/gradyzhuo/swift-kurrentdb/actions/workflows/swift-build-testing.yml"><img src="https://github.com/gradyzhuo/swift-kurrentdb/actions/workflows/swift-build-testing.yml/badge.svg" alt="Build status"></a>
+    </div>
+
+    <div class="cta">
+      <a class="btn primary" href="#quick-start">Get Started · 開始使用</a>
+      <a class="btn" href="https://swiftpackageindex.com/gradyzhuo/swift-kurrentdb/documentation/kurrentdb" target="_blank" rel="noopener">Documentation</a>
+      <a class="btn" href="https://github.com/gradyzhuo/swift-kurrentdb" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </div>
+</header>
+
+<section id="install" class="container">
+  <h2>Install <span class="zh">安裝</span></h2>
+  <p>Add to your <code>Package.swift</code>:</p>
+  <p class="zh-p">在 <code>Package.swift</code> 加入：</p>
+  <pre><code class="lang-swift">dependencies: [
+    .package(url: "https://github.com/gradyzhuo/swift-kurrentdb.git", from: "2.0.3")
+]</code></pre>
+  <p class="note">🎉 <strong>2.0 is here</strong> — the target-based API is the recommended way to use swift-kurrentdb. Already on 1.x? Use <code>KurrentDB_V1</code> to keep your existing code while you migrate.</p>
+  <p class="note zh-p">🎉 <strong>2.0 已上線</strong>　目前推薦使用 target-based API。仍在 1.x？請改用 <code>KurrentDB_V1</code>，原本程式碼可繼續運作，遷移節奏自己決定。</p>
+</section>
+
+<section id="why" class="container">
+  <h2>Why swift-kurrentdb <span class="zh">為什麼選擇</span></h2>
+  <div class="features">
+    <div class="feature">
+      <h3>Native Swift</h3>
+      <p>Designed for Swift from the ground up — not a wrapper around another language's client.</p>
+      <p class="zh-p">從 Swift 角度設計，不是其他語言客戶端的轉接層。</p>
+    </div>
+    <div class="feature">
+      <h3>Modern Concurrency</h3>
+      <p>Full <code>async/await</code> throughout, with Swift 6 strict-concurrency compliance and zero <code>@unchecked Sendable</code>.</p>
+      <p class="zh-p">全面 <code>async/await</code>，符合 Swift 6 strict concurrency，零 <code>@unchecked Sendable</code>。</p>
+    </div>
+    <div class="feature">
+      <h3>Compile-Time Safety</h3>
+      <p>Target-based API rules out illegal operations (e.g. tombstoning <code>$all</code>) before they reach the wire.</p>
+      <p class="zh-p">Target-based API 讓不合法的操作（例如對 <code>$all</code> 下 tombstone）在編譯期就被擋下。</p>
+    </div>
+    <div class="feature">
+      <h3>Typed Errors</h3>
+      <p>Every operation throws <code>KurrentError</code> via typed throws — failure cases are exhaustive at compile time.</p>
+      <p class="zh-p">所有操作以 typed throws 拋出 <code>KurrentError</code>，錯誤處理在編譯期就被窮舉。</p>
+    </div>
+    <div class="feature">
+      <h3>Cluster-Ready</h3>
+      <p>First-class support for multi-node TLS clusters with gossip discovery and <code>NodePreference</code> routing.</p>
+      <p class="zh-p">原生支援多節點 TLS 叢集，含 gossip discovery 與 <code>NodePreference</code> 路由。</p>
+    </div>
+    <div class="feature">
+      <h3>Well-Documented</h3>
+      <p>Comprehensive DocC guides on Swift Package Index — getting started, appending events, projections, subscriptions, and more.</p>
+      <p class="zh-p">Swift Package Index 上有完整 DocC 指南：入門、寫入事件、Projections、訂閱等。</p>
+    </div>
+  </div>
+</section>
+
+<section id="quick-start" class="container">
+  <h2>Quick Start <span class="zh">快速上手</span></h2>
+
+  <h3>Connect <span class="zh">連線</span></h3>
+  <pre><code class="lang-swift">import KurrentDB
+
+// Local development — single node
+let settings = ClientSettings.localhost()
+    .authenticated(.credentials(username: "admin", password: "changeit"))
+
+// Production — remote cluster (TLS enabled by default)
+let production = ClientSettings.remote(
+    "node1.example.com:2113",
+    "node2.example.com:2113",
+    "node3.example.com:2113"
+).authenticated(.credentials(username: "admin", password: "changeit"))
+
+let client = KurrentDBClient(settings: settings)</code></pre>
+
+  <h3>Append &amp; Read Events <span class="zh">寫入與讀取事件</span></h3>
+  <pre><code class="lang-swift">// Create an event
+let event = EventData(
+    eventType: "OrderPlaced",
+    model: ["orderId": "order-123", "total": 99.99]
+)
+
+// Append to stream
+try await client.streams(specified: "orders").append(events: [event]) {
+    $0.expectedRevision = .any
+}
+
+// Read events
+let responses = try await client.streams(specified: "orders").read {
+    $0.revision = .start
+    $0.limit = 10
+}
+
+for try await response in responses {
+    if let event = try response.event {
+        print("Event: \(event.record.eventType)")
+    }
+}</code></pre>
+
+  <h3>Subscribe <span class="zh">訂閱</span></h3>
+  <pre><code class="lang-swift">// Catch-up subscription
+let subscription = try await client.streams(specified: "orders").subscribe()
+
+for try await event in subscription.events {
+    print("Live event: \(event.record.eventType)")
+}</code></pre>
+</section>
+
+<section id="api" class="container">
+  <h2>API at a glance <span class="zh">API 一覽</span></h2>
+  <p>The target-based design scopes every operation through a typed target — the compiler keeps you on rails.</p>
+  <p class="zh-p">所有操作都透過型別化的 target 進入，編譯器幫你守住合法的呼叫範圍。</p>
+
+  <div class="api-grid">
+    <div class="api-card">
+      <h3>Streams</h3>
+      <pre><code class="lang-swift">client.streams(specified: "orders")
+  .append(events: ...)
+  .read { ... }
+  .subscribe()
+  .delete()
+  .tombstone()
+
+client.allStreams.read { ... }
+client.allStreams.subscribe()</code></pre>
+    </div>
+
+    <div class="api-card">
+      <h3>Projections</h3>
+      <pre><code class="lang-swift">client.projections(of: .continuous(name: "x"))
+  .create(query: js)
+
+client.projections(name: "x")
+  .enable() / .disable()
+  .state(of: T.self)
+  .result(of: T.self)
+
+client.projections(of: .anyMode).list()</code></pre>
+    </div>
+
+    <div class="api-card">
+      <h3>Persistent Subscriptions</h3>
+      <pre><code class="lang-swift">client.persistentSubscriptions(
+    stream: "orders", group: "workers"
+).create {
+    $0.revision = .start
+    $0.settings.maxRetryCount = 5
+}
+
+// subscribe → ack / nack with park/retry</code></pre>
+    </div>
+
+    <div class="api-card">
+      <h3>Users · Operations · Gossip</h3>
+      <pre><code class="lang-swift">client.users.create(...)
+client.user("jane").enable()
+
+client.operations(of: .scavenge)
+  .startScavenge(...)
+
+let members = try await client.readCluster()</code></pre>
+    </div>
+  </div>
+</section>
+
+<section id="compat" class="container">
+  <h2>Server Compatibility <span class="zh">伺服器相容性</span></h2>
+  <table class="compat">
+    <thead>
+      <tr><th>Server Version</th><th>Status</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>KurrentDB 26.1</strong></td><td>✅</td><td>Full feature support · 全功能支援</td></tr>
+      <tr><td><strong>KurrentDB 26.0</strong></td><td>✅</td><td>Full feature support · 全功能支援</td></tr>
+      <tr><td><strong>KurrentDB 25.1</strong></td><td>✅</td><td>Full feature support · 全功能支援</td></tr>
+      <tr><td><strong>EventStoreDB 24.x</strong></td><td>✅</td><td>Core features · v2 batch append 尚未提供</td></tr>
+    </tbody>
+  </table>
+  <p>Tested in CI across Swift 6.0 / 6.1 / 6.2 / 6.3 against every supported server version.</p>
+  <p class="zh-p">CI 在 Swift 6.0 / 6.1 / 6.2 / 6.3 對所有支援版本進行完整整合測試。</p>
+</section>
+
+<footer class="container">
+  <div class="footer-links">
+    <a href="https://swiftpackageindex.com/gradyzhuo/swift-kurrentdb/documentation/kurrentdb" target="_blank" rel="noopener">Documentation</a>
+    <a href="https://swiftpackageindex.com/gradyzhuo/swift-kurrentdb/documentation/kurrentdb/migration-guide" target="_blank" rel="noopener">Migration Guide (1.x → 2.x)</a>
+    <a href="https://github.com/gradyzhuo/swift-kurrentdb" target="_blank" rel="noopener">GitHub</a>
+    <a href="https://github.com/gradyzhuo/swift-kurrentdb/discussions" target="_blank" rel="noopener">Discussions</a>
+    <a href="https://github.com/gradyzhuo/swift-kurrentdb/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
+  </div>
+  <p class="footer-meta">MIT License · Made by <a href="https://github.com/gradyzhuo" target="_blank" rel="noopener">Grady Zhuo</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,306 @@
+:root {
+  --accent: #F05138;
+  --accent-soft: #F0513820;
+  --bg: #ffffff;
+  --bg-alt: #f7f7f8;
+  --text: #1d1d1f;
+  --text-dim: #6e6e73;
+  --text-zh: #4a4a52;
+  --border: #e5e5ea;
+  --code-bg: #f5f5f7;
+  --code-text: #1d1d1f;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d0d0f;
+    --bg-alt: #15151a;
+    --text: #f5f5f7;
+    --text-dim: #9a9aa3;
+    --text-zh: #b8b8c0;
+    --border: #2a2a30;
+    --code-bg: #16161b;
+    --code-text: #e8e8ec;
+    --accent-soft: #F0513833;
+  }
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang TC", "Hiragino Sans", "Noto Sans CJK TC", sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+.container {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover { text-decoration: underline; }
+
+code {
+  font-family: "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+  font-size: 0.92em;
+  background: var(--code-bg);
+  color: var(--code-text);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+}
+
+pre {
+  background: var(--code-bg);
+  color: var(--code-text);
+  padding: 16px 20px;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  margin: 16px 0;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.88em;
+  line-height: 1.55;
+  color: inherit;
+}
+
+h1, h2, h3 {
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+h2 {
+  font-size: 1.8rem;
+  margin-top: 0;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.4em;
+}
+
+h3 {
+  font-size: 1.2rem;
+  margin-top: 1.8em;
+  margin-bottom: 0.4em;
+}
+
+h2 .zh, h3 .zh {
+  color: var(--text-zh);
+  font-weight: 500;
+  font-size: 0.7em;
+  margin-left: 0.4em;
+}
+
+p.zh-p {
+  color: var(--text-zh);
+  margin-top: -0.4em;
+}
+
+.dim { color: var(--text-dim); font-weight: normal; }
+
+.note {
+  background: var(--accent-soft);
+  border-left: 3px solid var(--accent);
+  padding: 12px 16px;
+  border-radius: 6px;
+  margin: 12px 0;
+}
+.note.zh-p { margin-top: 4px; }
+
+/* Hero */
+.hero {
+  background: var(--bg-alt);
+  border-bottom: 1px solid var(--border);
+  padding: 60px 0 48px;
+  text-align: center;
+}
+
+.hero-icon {
+  width: 96px;
+  height: 96px;
+  border-radius: 22px;
+  box-shadow: 0 6px 24px rgba(0,0,0,0.12);
+}
+
+.hero h1 {
+  font-size: 2.6rem;
+  margin: 18px 0 4px;
+  letter-spacing: -0.02em;
+}
+
+.tagline {
+  font-size: 1.15rem;
+  margin: 8px 0 4px;
+  font-weight: 500;
+}
+
+.tagline-zh {
+  font-size: 1.05rem;
+  color: var(--text-zh);
+  margin: 0 0 8px;
+}
+
+.subtagline {
+  color: var(--text-dim);
+  margin: 0 0 24px;
+  font-size: 0.95rem;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
+  margin: 20px 0 28px;
+}
+.badges img { vertical-align: middle; }
+
+.cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 8px;
+}
+
+.btn {
+  display: inline-block;
+  padding: 10px 20px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: background 0.15s, border-color 0.15s;
+}
+.btn:hover {
+  background: var(--bg);
+  text-decoration: none;
+  border-color: var(--text-dim);
+}
+.btn.primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+.btn.primary:hover {
+  background: #d8442d;
+  border-color: #d8442d;
+}
+
+/* Sections */
+section {
+  padding: 56px 0;
+  border-bottom: 1px solid var(--border);
+}
+section:last-of-type { border-bottom: none; }
+
+/* Features grid */
+.features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+  margin-top: 24px;
+}
+
+.feature {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 18px 20px;
+}
+.feature h3 {
+  margin: 0 0 6px;
+  font-size: 1.05rem;
+  color: var(--accent);
+}
+.feature p { margin: 6px 0; font-size: 0.93rem; }
+.feature p.zh-p { font-size: 0.88rem; }
+
+/* API grid */
+.api-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 18px;
+  margin-top: 24px;
+}
+
+.api-card {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px 18px;
+}
+.api-card h3 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+  color: var(--accent);
+}
+.api-card pre {
+  margin: 0;
+  font-size: 0.85em;
+}
+
+/* Compat table */
+table.compat {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 20px 0;
+  font-size: 0.95rem;
+}
+table.compat th,
+table.compat td {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+table.compat thead {
+  background: var(--bg-alt);
+}
+table.compat th {
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+}
+
+/* Footer */
+footer {
+  padding: 40px 0 32px;
+  text-align: center;
+  color: var(--text-dim);
+}
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  justify-content: center;
+  margin-bottom: 16px;
+}
+.footer-links a { font-size: 0.95rem; }
+.footer-meta {
+  margin: 0;
+  font-size: 0.88rem;
+}
+
+/* Mobile */
+@media (max-width: 600px) {
+  .hero { padding: 40px 0 32px; }
+  .hero h1 { font-size: 2rem; }
+  .tagline { font-size: 1rem; }
+  h2 { font-size: 1.5rem; }
+  section { padding: 40px 0; }
+  pre { padding: 12px 14px; font-size: 0.85em; }
+}


### PR DESCRIPTION
## Summary

Adds a bilingual (English + 繁體中文) GitHub Pages landing site for swift-kurrentdb, served from `/docs` on `main` once Pages is enabled. Single self-contained static page — no Jekyll, no build step, plain HTML + CSS.

### Page structure
- **Hero** — icon, name, tagline (English/中文), badges, primary CTAs (Get Started / Documentation / GitHub)
- **Install** — `Package.swift` snippet pinned to `from: "2.0.3"`, plus the "2.0 is here" note and `KurrentDB_V1` pointer for 1.x users
- **Why swift-kurrentdb** — 6-card feature grid (Native Swift, Modern Concurrency, Compile-Time Safety, Typed Errors, Cluster-Ready, Well-Documented)
- **Quick Start** — Connect, Append & Read, Subscribe; all snippets use the **verified 2.x API** (`client.streams(specified: …).append/read/subscribe`, `$0.revision = .start`, etc. — the same shape that landed in the README rewrite, not the older 1.x flat methods)
- **API at a glance** — Streams / Projections / Persistent Subscriptions / Users · Operations · Gossip in a 2×2 grid
- **Server Compatibility** — mirrors the README table (26.1 / 26.0 / 25.1 / EventStoreDB 24.x)
- **Footer** — Documentation / Migration Guide / GitHub / Discussions / Contributing

### Technical notes
- `docs/.nojekyll` prevents GitHub Pages from running Jekyll
- Dark/light mode via `prefers-color-scheme`; Swift orange (`#F05138`) as the only accent colour
- Mobile responsive (single breakpoint at 600px)
- No JS, no external fonts, no analytics — just two files plus the icon (loaded from the same Bluesky CDN URL the README already uses)
- All external links open in new tab with `rel=noopener`

### To enable Pages after merge

```bash
gh api -X POST /repos/gradyzhuo/swift-kurrentdb/pages \\
  -f 'source[branch]=main' -f 'source[path]=/docs'
```

The site will then be available at `https://gradyzhuo.github.io/swift-kurrentdb/` (usually within a minute or two of the first deploy).

## Test plan

- [ ] Preview locally: `open docs/index.html` and check the rendered layout, dark mode, and that all code blocks read as 2.x API
- [ ] On a phone viewport: confirm the feature grid and API grid collapse to single column cleanly
- [ ] Click each CTA / footer link, confirm destinations resolve
- [ ] After merge: enable Pages with the gh command above, wait for first deploy, visually verify the live URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive landing page with installation instructions, feature highlights, quick-start code examples, complete API reference with grouped samples, server compatibility matrix, and footer links.

* **Style**
  * Added complete site styling with dark mode support, responsive mobile design, typography hierarchy, and visual components for hero sections, API cards, and compatibility tables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gradyzhuo/swift-kurrentdb/pull/115)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->