### PR TITLE
[UPDATE] Spotlight 2.0.0 release on the GitHub Pages landing site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,7 @@
 <header class="hero">
   <div class="container">
     <img class="hero-icon" src="https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:fikpipzuggbnuqew3treexnn/bafkreiadjakshxna7sn2gtwxdibew7e66vp3xplpghr72sxpwptsq7gf3i@jpeg" alt="swift-kurrentdb icon">
+    <a href="#whats-new" class="version-pill">🚀 v2.0.0 · Target-based API has landed</a>
     <h1>swift-kurrentdb</h1>
     <p class="tagline">A modern, type-safe Swift client for Kurrent <span class="dim">(formerly EventStoreDB)</span></p>
     <p class="tagline-zh">為 Kurrent / EventStoreDB 而設計的現代化 Swift 客戶端</p>
@@ -48,6 +49,111 @@
 ]</code></pre>
   <p class="note">🎉 <strong>2.0 is here</strong> — the target-based API is the recommended way to use swift-kurrentdb. Already on 1.x? Use <code>KurrentDB_V1</code> to keep your existing code while you migrate.</p>
   <p class="note zh-p">🎉 <strong>2.0 已上線</strong>　目前推薦使用 target-based API。仍在 1.x？請改用 <code>KurrentDB_V1</code>，原本程式碼可繼續運作，遷移節奏自己決定。</p>
+</section>
+
+<section id="whats-new" class="container whats-new">
+  <div class="whats-new-tag">Major release · v2.0.0</div>
+  <h2>What's new in 2.0 <span class="zh">2.0 帶來了什麼</span></h2>
+  <p class="lead">
+    Version 2.0 is a <strong>ground-up redesign</strong> of the public API. The flat
+    <code>client.appendToStream(...)</code> surface gives way to typed targets the compiler can verify —
+    illegal operations literally don't compile.
+  </p>
+  <p class="lead zh-p">
+    2.0 是 API 的<strong>全面重新設計</strong>。原本 <code>client.appendToStream(...)</code> 的扁平呼叫，
+    換成編譯器能驗證的型別化 target — 不合法的操作根本通不過編譯。
+  </p>
+
+  <div class="highlights">
+    <div class="highlight">
+      <h3>🎯 Target-based API</h3>
+      <p>Every operation flows through a typed target. Tombstoning <code>$all</code>? Reading from a write-only target? Won't compile.</p>
+      <p class="zh-p">每個操作都透過型別化的 target 進入。對 <code>$all</code> 下 tombstone？編譯就過不去。</p>
+    </div>
+    <div class="highlight">
+      <h3>⚡️ Trailing-closure builders</h3>
+      <p>Options are mutated in an <code>inout</code> closure. No more options structs, no more parameter explosion.</p>
+      <p class="zh-p">用 <code>inout</code> closure 設定 options，告別參數爆炸與龐大的 options struct。</p>
+    </div>
+    <div class="highlight">
+      <h3>🛡️ Actor + Swift 6 strict concurrency</h3>
+      <p><code>KurrentDBClient</code> is an actor. The whole package compiles under <code>-strict-concurrency=complete</code> with zero <code>@unchecked Sendable</code>.</p>
+      <p class="zh-p"><code>KurrentDBClient</code> 是 actor。整個 package 在 <code>-strict-concurrency=complete</code> 下零 <code>@unchecked Sendable</code> 通過編譯。</p>
+    </div>
+    <div class="highlight">
+      <h3>📐 Typed throws</h3>
+      <p>Every operation throws <code>KurrentError</code> via typed throws — failure cases are exhaustive at compile time.</p>
+      <p class="zh-p">所有操作以 typed throws 拋出 <code>KurrentError</code>，錯誤處理在編譯期就被窮舉。</p>
+    </div>
+    <div class="highlight">
+      <h3>🧩 Three-layer module split</h3>
+      <p><code>KurrentDB</code> → <code>GRPCEncapsulates</code> → <code>Generated</code>. gRPC patterns live in their own module — reusable beyond KurrentDB.</p>
+      <p class="zh-p"><code>KurrentDB</code> → <code>GRPCEncapsulates</code> → <code>Generated</code> 三層拆分，gRPC 抽象可被其他客戶端重用。</p>
+    </div>
+    <div class="highlight">
+      <h3>🛟 1.x preserved as KurrentDB_V1</h3>
+      <p>The 1.x flat-method API ships in the same package under a separate library. Migrate at your own pace — your code keeps working today.</p>
+      <p class="zh-p">1.x 平面式 API 在同一個 package 內以獨立 library 保留。今天升級依舊跑得動，遷移節奏自己掌握。</p>
+    </div>
+  </div>
+
+  <h3>See the difference <span class="zh">前後對照</span></h3>
+  <div class="compare">
+    <div class="compare-col compare-old">
+      <h4>1.x · Flat methods</h4>
+      <pre><code class="lang-swift">// Append
+try await client.appendToStream(
+    "orders",
+    events: [event]
+) {
+    $0.revision(expected: .streamExists)
+}
+
+// Read
+let responses = try await client.readStream("orders") {
+    $0.startFrom(revision: .start).limit(50)
+}
+
+// Persistent subscription
+try await client.createPersistentSubscription(
+    stream: "orders",
+    groupName: "workers"
+) {
+    $0.startFrom(revision: .start)
+      .maxRetryCount(5)
+}</code></pre>
+    </div>
+    <div class="compare-col compare-new">
+      <h4>2.x · Target-based</h4>
+      <pre><code class="lang-swift">// Append
+try await client.streams(specified: "orders")
+    .append(events: [event]) {
+        $0.expectedRevision = .streamExists
+    }
+
+// Read
+let responses = try await client.streams(specified: "orders").read {
+    $0.revision = .start
+    $0.limit = 50
+}
+
+// Persistent subscription
+try await client.persistentSubscriptions(
+    stream: "orders", group: "workers"
+).create {
+    $0.revision = .start
+    $0.settings.maxRetryCount = 5
+}</code></pre>
+    </div>
+  </div>
+
+  <div class="cta-row">
+    <a class="btn primary" href="https://swiftpackageindex.com/gradyzhuo/swift-kurrentdb/documentation/kurrentdb/migration-guide" target="_blank" rel="noopener">Read the Migration Guide →</a>
+    <span class="cta-note">
+      Full 1.x → 2.x walkthrough with every breaking change documented.<br>
+      <span class="zh-p">完整 1.x → 2.x 遷移指南，每一個破壞性變更都有對照。</span>
+    </span>
+  </div>
 </section>
 
 <section id="why" class="container">

--- a/docs/style.css
+++ b/docs/style.css
@@ -135,8 +135,28 @@ p.zh-p {
 
 .hero h1 {
   font-size: 2.6rem;
-  margin: 18px 0 4px;
+  margin: 6px 0 4px;
   letter-spacing: -0.02em;
+}
+
+.version-pill {
+  display: inline-block;
+  margin: 18px 0 0;
+  padding: 5px 14px;
+  background: var(--accent);
+  color: #fff !important;
+  border-radius: 100px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  box-shadow: 0 4px 14px rgba(240, 81, 56, 0.35);
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+.version-pill:hover {
+  background: #d8442d;
+  text-decoration: none !important;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(240, 81, 56, 0.45);
 }
 
 .tagline {
@@ -295,6 +315,124 @@ footer {
   font-size: 0.88rem;
 }
 
+/* What's new in 2.0 */
+.whats-new {
+  background: linear-gradient(135deg, var(--accent-soft) 0%, transparent 70%);
+  border-radius: 16px;
+  padding: 36px 28px 44px;
+  margin: 32px auto;
+  border: 1px solid var(--border);
+}
+
+.whats-new-tag {
+  display: inline-block;
+  padding: 4px 12px;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 100px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.whats-new h2 {
+  border-bottom: none;
+  padding-bottom: 0;
+  font-size: 2rem;
+}
+
+.lead {
+  font-size: 1.05rem;
+  margin: 12px 0;
+  max-width: 760px;
+}
+.lead.zh-p { margin-top: 4px; }
+
+.highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+  margin: 28px 0 36px;
+}
+
+.highlight {
+  padding: 18px 20px;
+  border-radius: 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+.highlight:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.06);
+}
+.highlight h3 {
+  margin: 0 0 8px;
+  font-size: 1.02rem;
+  color: var(--text);
+}
+.highlight p {
+  margin: 6px 0;
+  font-size: 0.92rem;
+}
+.highlight p.zh-p {
+  font-size: 0.87rem;
+}
+
+.compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin: 16px 0 24px;
+}
+.compare-col h4 {
+  margin: 0 0 8px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+}
+.compare-old h4::before {
+  content: "↩ ";
+  color: var(--text-dim);
+}
+.compare-new h4 {
+  color: var(--accent);
+}
+.compare-new h4::before {
+  content: "→ ";
+}
+.compare-col pre {
+  margin: 0;
+  font-size: 0.82em;
+  height: 100%;
+}
+.compare-new pre {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-soft);
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 18px;
+  margin-top: 8px;
+}
+.cta-note {
+  color: var(--text-dim);
+  font-size: 0.88rem;
+  flex: 1;
+  min-width: 220px;
+}
+
+@media (max-width: 720px) {
+  .compare { grid-template-columns: 1fr; }
+}
+
 /* Mobile */
 @media (max-width: 600px) {
   .hero { padding: 40px 0 32px; }
@@ -303,4 +441,6 @@ footer {
   h2 { font-size: 1.5rem; }
   section { padding: 40px 0; }
   pre { padding: 12px 14px; font-size: 0.85em; }
+  .whats-new { padding: 28px 20px 32px; margin: 20px 12px; }
+  .whats-new h2 { font-size: 1.6rem; }
 }


### PR DESCRIPTION
## Summary

The existing 🎉 install note for 2.0 was a single sentence buried under the `Package.swift` snippet — easy to miss for a visitor landing cold on the page. This PR pulls the 2.0 announcement up to hero level and dedicates a full section to what's actually new, so the dramatic API redesign is the first thing the page communicates.

### What changes

**Hero pill.** A "🚀 v2.0.0 · Target-based API has landed" pill in Swift orange, sitting above the project title, anchor-linked to `#whats-new`. Visible above the fold on every viewport.

**New `What's new in 2.0` section** between Install and Why, styled as a bordered, soft-gradient panel so it visually breaks the rhythm of the rest of the page:

- Lead paragraph framing 2.0 as a ground-up redesign — bilingual (EN + 繁中)
- **6 highlight cards** covering the dramatic changes:
  - 🎯 Target-based API
  - ⚡️ Trailing-closure builders
  - 🛡️ Actor + Swift 6 strict concurrency
  - 📐 Typed throws
  - 🧩 Three-layer module split
  - 🛟 1.x preserved as `KurrentDB_V1`
- **Side-by-side 1.x vs 2.x code comparison** for append / read / persistent subscription. The 2.x column has an accent border + soft glow so the new shape draws the eye. The 1.x column carries an `↩` glyph; the 2.x column carries a `→` glyph and accent-orange heading — visual cue for "before vs after"
- **"Read the Migration Guide" CTA** linking to the SPI migration doc

**Responsive behaviour.** Comparison columns stack to a single column below 720px; the whats-new panel padding tightens further below 600px.

**No content removed.** The original 🎉 install note stays put as a quick teaser that drops people into the deeper section.

## Test plan

- [ ] Local preview (`open docs/index.html`): hero pill renders above the title, anchor-scrolls to whats-new section
- [ ] All six highlight cards present and readable; English + 中文 both render
- [ ] Side-by-side comparison readable on desktop, stacks cleanly under 720px viewport
- [ ] Dark mode: gradient and accent border still legible
- [ ] After merge: GitHub Pages auto-redeploys; live URL shows the new section within ~1 min