### PR TITLE
[FIX] Remove v2.0.0 hero pill on the landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,6 @@
 <header class="hero">
   <div class="container">
     <img class="hero-icon" src="https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:fikpipzuggbnuqew3treexnn/bafkreiadjakshxna7sn2gtwxdibew7e66vp3xplpghr72sxpwptsq7gf3i@jpeg" alt="swift-kurrentdb icon">
-    <a href="#whats-new" class="version-pill">🚀 v2.0.0 · Target-based API has landed</a>
     <h1>swift-kurrentdb</h1>
     <p class="tagline">A modern, type-safe Swift client for Kurrent <span class="dim">(formerly EventStoreDB)</span></p>
     <p class="tagline-zh">為 Kurrent / EventStoreDB 而設計的現代化 Swift 客戶端</p>

--- a/docs/style.css
+++ b/docs/style.css
@@ -135,28 +135,8 @@ p.zh-p {
 
 .hero h1 {
   font-size: 2.6rem;
-  margin: 6px 0 4px;
+  margin: 18px 0 4px;
   letter-spacing: -0.02em;
-}
-
-.version-pill {
-  display: inline-block;
-  margin: 18px 0 0;
-  padding: 5px 14px;
-  background: var(--accent);
-  color: #fff !important;
-  border-radius: 100px;
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  box-shadow: 0 4px 14px rgba(240, 81, 56, 0.35);
-  transition: transform 0.15s, box-shadow 0.15s;
-}
-.version-pill:hover {
-  background: #d8442d;
-  text-decoration: none !important;
-  transform: translateY(-1px);
-  box-shadow: 0 6px 18px rgba(240, 81, 56, 0.45);
 }
 
 .tagline {


### PR DESCRIPTION
## Summary

The \`🚀 v2.0.0 · Target-based API has landed\` pill that #116 added to the hero was rendering inline alongside the icon and pushing it off-center. Drop it for now.

The pill anchor-linked into the \`What's new in 2.0\` section, which already has its own prominent panel right under Install — visitors aren't missing the 2.0 announcement without it.

### Files

- \`docs/index.html\` — remove the \`<a class=\"version-pill\">\` line above \`<h1>\`
- \`docs/style.css\` — drop the \`.version-pill\` rules and revert the \`.hero h1\` top margin back to the pre-pill value (\`18px 0 4px\`)

## Test plan

- [ ] \`open docs/index.html\` — icon sits centered above the title, no pill artifact
- [ ] After merge: GitHub Pages redeploys; live URL shows the hero with just icon + title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed version pill from the documentation header.

* **Style**
  * Adjusted spacing for the main title heading on the documentation page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gradyzhuo/swift-kurrentdb/pull/117)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->